### PR TITLE
Add/modify NPM test scripts. Move Puppeteer's cache directory to the project's root.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /node_modules
 /.pnp
 .pnp.js
+.cache
+package-lock.json
 
 # testing
 /coverage

--- a/.puppeteerrc.cjs
+++ b/.puppeteerrc.cjs
@@ -1,0 +1,5 @@
+const {join} = require('path');
+
+module.exports = {
+  cacheDirectory: join(__dirname, '.cache', 'puppeteer'),
+};

--- a/README.md
+++ b/README.md
@@ -5,27 +5,31 @@
 Install dependencies and build the project.
 
 ```
+npm install
 npm run build
 ```
 
 Integration tests and end-to-end tests make use of the Firebase Local Emulator Suite.
 
 
-The emulator suite requires Java JDK version 11 or higher and the [Firebase CLI](https://github.com/firebase/firebase-tools) to be installed.
+The emulator suite requires Java JDK version 11 or higher and the [Firebase CLI](https://github.com/firebase/firebase-tools) must be installed. The Firebase CLI, firebase-tools, is included as a development dependency.
 
-Log-in to Firebase.
-
-```
-firebase login
-```
-
-Set environment variables. Add a file `.env.local` to the project root. Ensure the `FIREBASE_EMULATOR_FIRESTORE_PORT` matches its port assignment in `firebase.json`.
+Set environment variables. Add a file `.env.local` to the project root. Ensure the `FIREBASE_EMULATOR_FIRESTORE_PORT` matches its port assignment in `firebase.json`. Add the following line to `.env.local`:
 
 ```
 FIREBASE_EMULATOR_FIRESTORE_PORT=8080
 ```
 
-A `firebase.json` configuration must be present in the project's root directory. The following `firebase.json` file can be used for running tests. The default Firebase emulator ports are used.
+Add a `.firebaserc` file to the root directory with the following contents:
+```
+{
+  "projects": {
+    "default": "demo-baby-equipment-exchange"
+  }
+}
+```
+
+A `firebase.json` configuration must be present in the project's root directory. The following `firebase.json` file can be used for running tests. The default Firebase emulator ports are used in this example for use with the emulator suite:
 
 ```
 {
@@ -50,8 +54,7 @@ A `firebase.json` configuration must be present in the project's root directory.
 }
 ```
 
-Ensure `storage.rules` is present in the root directory. The following configuration can be used when using the Firebase Emulator Suite.
-
+Ensure `storage.rules` is present in the root directory. The following configuration can be used when using the Firebase Emulator Suite:
 ```
 rules_version = "2";
 service firebase.storage {
@@ -63,6 +66,5 @@ service firebase.storage {
 }
 ```
 
-Test with the emulator suite by calling the following command in the root directory. The data directory is specified with the `--import` flag.
-
-`firebase emulators:exec "npm run test" --import=<emulator-data-directory>`.
+Test with the emulator suite by calling the following command in the root directory, the data directory is specified with the `--import` flag:
+`npx ./node_modules/firebase-tools emulators:exec "npm run test" --import=<emulator-data-directory>`.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "private": true,
     "scripts": {
         "dev": "next dev",
-        "test": "node ./node_modules/jest/bin/jest.js -- --config=./jest.config.js ./",
-        "test:emulator": "node ", 
+        "test": "npx ./node_modules/jest -- --config=./jest.config.js ./",
+        "test:emulator": "npx ./node_modules/firebase-tools emulators:exec \"npm run test\"",
         "build": "next build",
         "start": "next start",
         "lint": "next lint",


### PR DESCRIPTION
This request modifies the _test_ npm script to invoke the project's local Jest npm package with npx. The _test:emulator_ npm script now calls the npm _test_ script with the _firebase-tools_ emulator.

A Puppeteer configuration file has been added to store Puppeteer's dependencies within the project root. By default Puppeteer's dependencies (e.g. Browsers) are downloaded to the user's home directory.

The .cache directory and package-lock.json have been added to the .gitignore .