### PR TITLE
CI/CD using github actions

### DIFF
--- a/.github/workflows/deploy-images.yml
+++ b/.github/workflows/deploy-images.yml
@@ -1,0 +1,48 @@
+#
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    branches: ['main']
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy-images.yml
+++ b/.github/workflows/deploy-images.yml
@@ -36,6 +36,9 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.

--- a/.github/workflows/deploy-images.yml
+++ b/.github/workflows/deploy-images.yml
@@ -47,3 +47,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            FIREBASE_CONFIG_BASE64=${{secrets.FIREBASE_CONFIG_BASE64}}
+            SERVICE_ACCOUNT_BASE64=${{secrets.SERVICE_ACCOUNT_BASE64}}

--- a/.github/workflows/deploy-images.yml
+++ b/.github/workflows/deploy-images.yml
@@ -39,6 +39,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=sha
+            latest
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,3 @@ serviceAccount.json
 #VSCODE Preferences
 .vscode
 
-# personal containers
-/.devcontainer/**
-.github

--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@ This project assists the collection and distribution of unused and gently used b
 1. install Docker desktop (or equivalent in Mac and Linux)
 
 2. the Docker image is hosted in a the GitHub Packages repository, you'll need to authenticate with GitHub Packages to pull and run the image.you need to authenticate using a GitHub Personal Access Token (PAT) with at least read:packages permission. If you haven't already, generate a PAT by following these steps:
-- Go to GitHub and log in.
-- Click on your profile picture in the top right corner and go to Settings.
-- On the left sidebar, click Developer settings.
-- Click on Personal access tokens and then Generate new token.
-- Give your token a name, set the expiration, and select at least the read:packages scope under package permissions. - If you also want to push or delete packages, select the appropriate additional scopes.
-- Click Generate token at the bottom of the page and make sure to copy your new personal access token; you won't be able to see it again.
-3. Log in to GitHub Packages
+- go to GitHub and log in.
+- click on your profile picture in the top right corner and go to Settings.
+- on the left sidebar, click Developer settings.
+- click on Personal access tokens and then Generate new token.
+- give your token a name, set the expiration, and select at least the read:packages scope under package permissions. - If you also want to push or delete packages, select the appropriate additional scopes.
+- click Generate token at the bottom of the page and make sure to copy your new personal access token; you won't be able to see it again.
+3. log in to GitHub Packages
 Use the docker login command to authenticate with GitHub Packages, use the PAT you just created for CR_PAT:
 ```
 export CR_PAT="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 echo $CR_PAT | docker login ghcr.io -u codeforbtv --password-stdin
 ```
-4. Now that you're authenticated, you can pull and run the Docker image
+4. now that you're authenticated, you can pull and run the Docker image
 ```
 docker pull ghcr.io/codeforbtv/baby-equipment-exchange:latest
 ```
@@ -31,12 +31,12 @@ docker run -dit -p 3000:3000 -p 4000:4000 -p 5000:5000 -p 4400:4400 -p 4500:4500
 ```
 6. install visual studio code.
 7. run visual studio code and install Visual Studio Code Dev Containers extension, for documentation on this extension (https://code.visualstudio.com/docs/devcontainers/containers)
-8. Download VScode extension called "Remote Development"
+8. download VScode extension called "Remote Development"
 9. in visual studio code press ctrl+shit+p to open command palette and select Dev Containers: Attach to Running Container (https://code.visualstudio.com/docs/devcontainers/attach-container)
 10. select the Attach to Container inline action on the container you want to connect to
 11. verify your connection by going to the remote tab in VScode
 12. open folder and navigate to /home/user/projects/baby-equipment-exchange/
-13. Create a new file called serviceAccount.json, you need to contact the repo admin to get the content of this file
+13. create a new file called serviceAccount.json, you need to contact the repo admin to get the content of this file
 14. open a new terminal in VScode (verify that it's connected to the container not your host machine) the following command should start the emulators and the app:
 ```
 export GOOGLE_APPLICATION_CREDENTIALS="/home/user/projects/baby-equipment-exchange/serviceAccount.json"

--- a/README.md
+++ b/README.md
@@ -36,14 +36,15 @@ docker run -dit -p 3000:3000 -p 4000:4000 -p 5000:5000 -p 4400:4400 -p 4500:4500
 10. select the Attach to Container inline action on the container you want to connect to
 11. verify your connection by going to the remote tab in VScode
 12. open folder and navigate to /home/user/projects/baby-equipment-exchange/
-13. open a new terminal in VScode (verify that it's connected to the container not your host machine) the following command should start the emulators and the app:
+13. Create a new file called serviceAccount.json, you need to contact the repo admin to get the content of this file
+14. open a new terminal in VScode (verify that it's connected to the container not your host machine) the following command should start the emulators and the app:
 ```
-
+export GOOGLE_APPLICATION_CREDENTIALS="/home/user/projects/baby-equipment-exchange/serviceAccount.json"
 export FIREBASE_CONFIG="$(cat /home/user/projects/baby-equipment-exchange/firebaseConfig.json)"
 npm run dev
 
 ```
-14. see the output you can run in your host machine browser http://localhost:3000
+15. see the output you can run in your host machine browser http://localhost:3000
 
 
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,26 @@ This project assists the collection and distribution of unused and gently used b
 ## Dev remote Setup (Recommended for consistency, you can dev local if you don't want to work with docker)
 
 1. install Docker desktop (or equivalent in Mac and Linux)
+
+2. the Docker image is hosted in a the GitHub Packages repository, you'll need to authenticate with GitHub Packages to pull and run the image.you need to authenticate using a GitHub Personal Access Token (PAT) with at least read:packages permission. If you haven't already, generate a PAT by following these steps:
+- Go to GitHub and log in.
+- Click on your profile picture in the top right corner and go to Settings.
+- On the left sidebar, click Developer settings.
+- Click on Personal access tokens and then Generate new token.
+- Give your token a name, set the expiration, and select at least the read:packages scope under package permissions. - If you also want to push or delete packages, select the appropriate additional scopes.
+- Click Generate token at the bottom of the page and make sure to copy your new personal access token; you won't be able to see it again.
+3. Log in to GitHub Packages
+Use the docker login command to authenticate with GitHub Packages, replacing USERNAME with your GitHub username and TOKEN with the PAT you just created:
+```
+export CR_PAT="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+echo $CR_PAT | docker login ghcr.io -u codeforbtv --password-stdin
+```
+4. Now that you're authenticated, you can pull and run the Docker image
+```
+docker pull ghcr.io/codeforbtv/baby-equipment-exchange:latest
+```
+
+
 2. download folder "docker_image_build_files" from the repo, it's better not to clone the entire repo because you will not develop on this cloned repo 
 3. you still need 2 additional files to authernticate locally contact the repo admin to get them, you need "firebaseConfig.json" and "serviceAccount.json", after you acquire them put those 2 files inside the  "/docker_image_build_files/firebase_emulator_files/"
 4. install visual studio code.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project assists the collection and distribution of unused and gently used b
 - Give your token a name, set the expiration, and select at least the read:packages scope under package permissions. - If you also want to push or delete packages, select the appropriate additional scopes.
 - Click Generate token at the bottom of the page and make sure to copy your new personal access token; you won't be able to see it again.
 3. Log in to GitHub Packages
-Use the docker login command to authenticate with GitHub Packages, replacing USERNAME with your GitHub username and TOKEN with the PAT you just created:
+Use the docker login command to authenticate with GitHub Packages, use the PAT you just created for CR_PAT:
 ```
 export CR_PAT="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 echo $CR_PAT | docker login ghcr.io -u codeforbtv --password-stdin
@@ -25,20 +25,12 @@ echo $CR_PAT | docker login ghcr.io -u codeforbtv --password-stdin
 ```
 docker pull ghcr.io/codeforbtv/baby-equipment-exchange:latest
 ```
-
-
-2. download folder "docker_image_build_files" from the repo, it's better not to clone the entire repo because you will not develop on this cloned repo 
-3. you still need 2 additional files to authernticate locally contact the repo admin to get them, you need "firebaseConfig.json" and "serviceAccount.json", after you acquire them put those 2 files inside the  "/docker_image_build_files/firebase_emulator_files/"
-4. install visual studio code.
-5. run visual studio code and install Visual Studio Code Dev Containers extension, for documentation on this extension (https://code.visualstudio.com/docs/devcontainers/containers)
-6. open a terminal, navigate to "/docker_image_build_files/" and run the below lines to build a docker image (if we find a way to secure some of the json files we can just share the docker image)
+5. run the docker container
 ```
-docker build -t babyequipments:1.01 .
+docker run -dit -p 3000:3000 -p 4000:4000 -p 5000:5000 -p 4400:4400 -p 4500:4500 -p 9099:9099 -p 8080:8080 -p 9150:9150 -p 9199:9199 --name baby-equipment-app ghcr.io/abdullahalhoothy/baby-equipment-exchange:latest
 ```
-7. run the below to run a docker container  
-```
-docker run -dit -p 3000:3000 -p 4000:4000 -p 5000:5000 -p 4400:4400 -p 4500:4500 -p 9099:9099 -p 8080:8080 -p 9150:9150 -p 9199:9199 --name baby-equipment-app babyequipments:1.01
-```
+6. install visual studio code.
+7. run visual studio code and install Visual Studio Code Dev Containers extension, for documentation on this extension (https://code.visualstudio.com/docs/devcontainers/containers)
 8. Download VScode extension called "Remote Development"
 9. in visual studio code press ctrl+shit+p to open command palette and select Dev Containers: Attach to Running Container (https://code.visualstudio.com/docs/devcontainers/attach-container)
 10. select the Attach to Container inline action on the container you want to connect to
@@ -52,6 +44,9 @@ npm run dev
 
 ```
 14. see the output you can run in your host machine browser http://localhost:3000
+
+
+
 
 
 ## Dev Local Setup

--- a/docker_image_build_files/Dockerfile
+++ b/docker_image_build_files/Dockerfile
@@ -28,7 +28,7 @@ ARG REPO_DIR="/home/user/projects/baby-equipment-exchange"
 RUN git clone ${GITHUB_REPO}
 WORKDIR ${REPO_DIR}
 RUN git checkout main
-
+RUN mkdir -p data_directory
 
 
 # the below envinroment variables should be passed through terraform

--- a/docker_image_build_files/Dockerfile
+++ b/docker_image_build_files/Dockerfile
@@ -60,8 +60,8 @@ RUN npm install && \
     npm install && \
     npm run build && \
     cd /home/user/projects/baby-equipment-exchange && \
-    npm run build && \
-    firebase experiments:enable webframeworks
+    npm run build
+RUN firebase experiments:enable webframeworks
 
 
 # Define a volume in the image, this is to be passed from terraform

--- a/docker_image_build_files/Dockerfile
+++ b/docker_image_build_files/Dockerfile
@@ -55,11 +55,13 @@ ENV CYPRESS_INSTALL_BINARY=0
 
 # Use a RUN command to export the environment variables
 RUN export FIREBASE_CONFIG="$(cat /home/user/projects/baby-equipment-exchange/firebaseConfig.json | jq -c .)" 
-RUN npm install && \
-    cd /home/user/projects/baby-equipment-exchange/functions && \
+RUN npm install
+
+RUN cd /home/user/projects/baby-equipment-exchange/functions && \
     npm install && \
-    npm run build && \
-    cd /home/user/projects/baby-equipment-exchange && \
+    npm run build
+
+RUN cd /home/user/projects/baby-equipment-exchange && \
     npm run build
 RUN firebase experiments:enable webframeworks
 

--- a/docker_image_build_files/Dockerfile
+++ b/docker_image_build_files/Dockerfile
@@ -61,8 +61,8 @@ RUN cd /home/user/projects/baby-equipment-exchange/functions && \
     npm install && \
     npm run build
 
-RUN cd /home/user/projects/baby-equipment-exchange && \
-    npm run build
+RUN cd /home/user/projects/baby-equipment-exchange
+RUN npm run build
 RUN firebase experiments:enable webframeworks
 
 

--- a/docker_image_build_files/Dockerfile
+++ b/docker_image_build_files/Dockerfile
@@ -28,7 +28,7 @@ ARG REPO_DIR="/home/user/projects/baby-equipment-exchange"
 RUN git clone ${GITHUB_REPO}
 WORKDIR ${REPO_DIR}
 RUN git checkout main
-RUN mkdir -p data_directory
+RUN mkdir -p /home/user/projects/baby-equipment-exchange/data_directory/
 
 
 # the below envinroment variables should be passed through terraform

--- a/docker_image_build_files/Dockerfile
+++ b/docker_image_build_files/Dockerfile
@@ -54,8 +54,8 @@ ENV GOOGLE_APPLICATION_CREDENTIALS="/home/user/projects/baby-equipment-exchange/
 ENV CYPRESS_INSTALL_BINARY=0
 
 # Use a RUN command to export the environment variables
-RUN export FIREBASE_CONFIG="$(cat /home/user/projects/baby-equipment-exchange/firebaseConfig.json | jq -c .)" && \
-    npm install && \
+RUN export FIREBASE_CONFIG="$(cat /home/user/projects/baby-equipment-exchange/firebaseConfig.json | jq -c .)" 
+RUN npm install && \
     cd /home/user/projects/baby-equipment-exchange/functions && \
     npm install && \
     npm run build && \

--- a/docker_image_build_files/Dockerfile
+++ b/docker_image_build_files/Dockerfile
@@ -42,6 +42,14 @@ ARG FIREBASE_CONFIG
 ENV FIREBASE_CONFIG=$FIREBASE_CONFIG
 RUN chmod +x /home/user/projects/baby-equipment-exchange/
 
+# Accept build-time variables
+ARG FIREBASE_CONFIG_BASE64
+ARG SERVICE_ACCOUNT_BASE64
+
+# Use a RUN command to create the files from the arguments
+RUN echo "$FIREBASE_CONFIG_BASE64" | base64 -d > /home/user/projects/baby-equipment-exchange/firebaseConfig.json
+RUN echo "$SERVICE_ACCOUNT_BASE64" | base64 -d > /home/user/projects/baby-equipment-exchange/serviceAccount.json
+
 
 RUN npm install -g firebase-tools
 RUN touch /home/user/projects/baby-equipment-exchange/.env.local
@@ -54,16 +62,14 @@ ENV GOOGLE_APPLICATION_CREDENTIALS="/home/user/projects/baby-equipment-exchange/
 ENV CYPRESS_INSTALL_BINARY=0
 
 # Use a RUN command to export the environment variables
-RUN export FIREBASE_CONFIG="$(cat /home/user/projects/baby-equipment-exchange/firebaseConfig.json | jq -c .)" 
-RUN npm install
-
-RUN cd /home/user/projects/baby-equipment-exchange/functions && \
+RUN export FIREBASE_CONFIG="$(cat /home/user/projects/baby-equipment-exchange/firebaseConfig.json | jq -c .)" && \
     npm install && \
-    npm run build
-
-RUN cd /home/user/projects/baby-equipment-exchange
-RUN npm run build
-RUN firebase experiments:enable webframeworks
+    cd /home/user/projects/baby-equipment-exchange/functions && \
+    npm install && \
+    npm run build && \
+    cd /home/user/projects/baby-equipment-exchange && \
+    npm run build && \
+    firebase experiments:enable webframeworks
 
 
 # Define a volume in the image, this is to be passed from terraform

--- a/docker_image_build_files/Dockerfile
+++ b/docker_image_build_files/Dockerfile
@@ -6,6 +6,15 @@ RUN apt-get update && \
     apt-get install -y git default-jdk jq && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+RUN wget https://chromedriver.storage.googleapis.com/94.0.4606.61/chromedriver_linux64.zip && \
+    unzip chromedriver_linux64.zip && \
+    mv chromedriver /usr/bin/chromedriver && \
+    chmod +x /usr/bin/chromedriver && \
+    rm -f chromedriver_linux64.zip
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+    dpkg -i google-chrome-stable_current_amd64.deb || true && \
+    apt-get install -f -y && \
+    rm -f google-chrome-stable_current_amd64.deb
 
 RUN mkdir -p /home/user/projects/
 WORKDIR /home/user/projects/
@@ -21,17 +30,10 @@ WORKDIR ${REPO_DIR}
 RUN git checkout main
 
 
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
-    dpkg -i google-chrome-stable_current_amd64.deb || true && \
-    apt-get install -f -y && \
-    rm -f google-chrome-stable_current_amd64.deb
+
 # the below envinroment variables should be passed through terraform
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome
-RUN wget https://chromedriver.storage.googleapis.com/94.0.4606.61/chromedriver_linux64.zip && \
-    unzip chromedriver_linux64.zip && \
-    mv chromedriver /usr/bin/chromedriver && \
-    chmod +x /usr/bin/chromedriver && \
-    rm -f chromedriver_linux64.zip
+
 # in the future the below files need to be passed through terraform
 # at the moment the json files must be in the same directory as the dockerfile
 # Copy all JSON files from the Dockerfile's directory to the specified working directory in the Docker image
@@ -45,7 +47,6 @@ RUN chmod +x /home/user/projects/baby-equipment-exchange/
 # Accept build-time variables
 ARG FIREBASE_CONFIG_BASE64
 ARG SERVICE_ACCOUNT_BASE64
-
 # Use a RUN command to create the files from the arguments
 RUN echo "$FIREBASE_CONFIG_BASE64" | base64 -d > /home/user/projects/baby-equipment-exchange/firebaseConfig.json
 RUN echo "$SERVICE_ACCOUNT_BASE64" | base64 -d > /home/user/projects/baby-equipment-exchange/serviceAccount.json
@@ -62,14 +63,15 @@ ENV GOOGLE_APPLICATION_CREDENTIALS="/home/user/projects/baby-equipment-exchange/
 ENV CYPRESS_INSTALL_BINARY=0
 
 # Use a RUN command to export the environment variables
-RUN export FIREBASE_CONFIG="$(cat /home/user/projects/baby-equipment-exchange/firebaseConfig.json | jq -c .)" && \
+RUN export FIREBASE_CONFIG="$(cat /home/user/projects/baby-equipment-exchange/firebaseConfig.json | jq -c .)"  && \
     npm install && \
     cd /home/user/projects/baby-equipment-exchange/functions && \
     npm install && \
     npm run build && \
     cd /home/user/projects/baby-equipment-exchange && \
-    npm run build && \
-    firebase experiments:enable webframeworks
+    firebase experiments:enable webframeworks && \
+    npm run build 
+    
 
 
 # Define a volume in the image, this is to be passed from terraform

--- a/docker_image_build_files/Dockerfile
+++ b/docker_image_build_files/Dockerfile
@@ -56,9 +56,9 @@ RUN npm install -g firebase-tools
 RUN touch /home/user/projects/baby-equipment-exchange/.env.local
 # the below envinroment variables should be passed through terraform
 RUN echo 'GOOGLE_APPLICATION_CREDENTIALS="/home/user/projects/baby-equipment-exchange/serviceAccount.json"' >> /home/user/projects/baby-equipment-exchange/.env.local
-RUN echo 'FIREBASE_EMULATORS_IMPORT_DIRECTORY="./data_directory"' >> /home/user/projects/baby-equipment-exchange/.env.local
+RUN echo 'FIREBASE_EMULATORS_IMPORT_DIRECTORY="/home/user/projects/baby-equipment-exchange/data_directory/"' >> /home/user/projects/baby-equipment-exchange/.env.local
 RUN echo FIREBASE_CONFIG=\"$(jq -c . < firebaseConfig.json)\" >> .env.local
-ENV FIREBASE_EMULATORS_IMPORT_DIRECTORY="./data_directory"
+ENV FIREBASE_EMULATORS_IMPORT_DIRECTORY="/home/user/projects/baby-equipment-exchange/data_directory/"
 ENV GOOGLE_APPLICATION_CREDENTIALS="/home/user/projects/baby-equipment-exchange/serviceAccount.json"
 ENV CYPRESS_INSTALL_BINARY=0
 

--- a/docker_image_build_files/Dockerfile
+++ b/docker_image_build_files/Dockerfile
@@ -44,22 +44,20 @@ ARG FIREBASE_CONFIG
 ENV FIREBASE_CONFIG=$FIREBASE_CONFIG
 RUN chmod +x /home/user/projects/baby-equipment-exchange/
 
-# Accept build-time variables
-ARG FIREBASE_CONFIG_BASE64
-ARG SERVICE_ACCOUNT_BASE64
-# Use a RUN command to create the files from the arguments
-RUN echo "$FIREBASE_CONFIG_BASE64" | base64 -d > /home/user/projects/baby-equipment-exchange/firebaseConfig.json
-RUN echo "$SERVICE_ACCOUNT_BASE64" | base64 -d > /home/user/projects/baby-equipment-exchange/serviceAccount.json
-
 
 RUN npm install -g firebase-tools
 RUN touch /home/user/projects/baby-equipment-exchange/.env.local
-# the below envinroment variables should be passed through terraform
-RUN echo 'GOOGLE_APPLICATION_CREDENTIALS="/home/user/projects/baby-equipment-exchange/serviceAccount.json"' >> /home/user/projects/baby-equipment-exchange/.env.local
-RUN echo 'FIREBASE_EMULATORS_IMPORT_DIRECTORY="/home/user/projects/baby-equipment-exchange/data_directory/"' >> /home/user/projects/baby-equipment-exchange/.env.local
+
+# Accept build-time variables
+ARG FIREBASE_CONFIG_BASE64
+# Use a RUN command to create the files from the arguments
+RUN echo "$FIREBASE_CONFIG_BASE64" | base64 -d > /home/user/projects/baby-equipment-exchange/firebaseConfig.json
 RUN echo FIREBASE_CONFIG=\"$(jq -c . < firebaseConfig.json)\" >> .env.local
+
+# the below envinroment variables should be passed through terraform
+RUN echo 'FIREBASE_EMULATORS_IMPORT_DIRECTORY="/home/user/projects/baby-equipment-exchange/data_directory/"' >> /home/user/projects/baby-equipment-exchange/.env.local
 ENV FIREBASE_EMULATORS_IMPORT_DIRECTORY="/home/user/projects/baby-equipment-exchange/data_directory/"
-ENV GOOGLE_APPLICATION_CREDENTIALS="/home/user/projects/baby-equipment-exchange/serviceAccount.json"
+
 ENV CYPRESS_INSTALL_BINARY=0
 
 # Use a RUN command to export the environment variables


### PR DESCRIPTION
Instead of building Docker images locally on every persons computer. i'm thinking we should use Github container registry
Can someone who's an admin connect the package to the repository
That way we can use also CICD within Github actions 
I've made several updates to our project's Docker setup and GitHub Actions workflow to enhance our CI/CD pipeline and containerization strategy. Below is a summary of the key changes:
Dockerfile Modifications:
Separation of Commands: I've updated the Dockerfile to separate some commands for better readability and maintainability.
Integration of GitHub Secrets: Modified the Dockerfile to use GitHub secrets (FIREBASE_CONFIG_BASE64, SERVICE_ACCOUNT_BASE64) for securely handling sensitive configurations.
Puppeteer and ChromeDriver Setup: Included steps to install Google Chrome and ChromeDriver, necessary for our Puppeteer tests.
Build-Time Variables: Added support for FIREBASE_CONFIG_BASE64 and SERVICE_ACCOUNT_BASE64 as build-time variables to dynamically create firebaseConfig.json and serviceAccount.json during the build. (let's use google Secret Manager in the future though )
GitHub Actions Workflow Enhancements:
Tagging Strategy: Modified our deployment workflow to always tag the last image deployed with "latest," ensuring an up-to-date deployment.
Metadata Extraction: Utilized docker/metadata-action to extract tags and labels for Docker images, including branch-specific tags, SHA tags, and the "latest" tag.
special attention to the updated Dockerfile and GitHub Actions workflow (deploy-images.yml).