### PR TITLE
SCSS refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-instantsearch": "^7.6.0",
-        "sass": "1.69.5",
         "tailwindcss": "3.4.1",
         "typescript": "5.2.2",
         "uuid": "^9.0.1"

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -135,9 +135,9 @@ export default function About() {
 
     return (
         <>
-            <div className={styles['about_container']}>
+            <div className="page--container">
                 <h1>About</h1>
-                <div className="content__container">
+                <div className="content--container">
                     <h2>The Project</h2>
                     <p>
                         Vermont Connector has launched the Baby & Child Product Exchange in partnership with twenty-five social services and mutual aid

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 //Styling
-import globalStyles from '@/styles/globalStyles.module.scss';
+import '../../styles/globalStyles.css';
 import styles from './About.module.css';
 import { ReactNode } from 'react';
 import Link from 'next/link';
@@ -137,7 +137,7 @@ export default function About() {
         <>
             <div className={styles['about_container']}>
                 <h1>About</h1>
-                <div className={globalStyles['content__container']}>
+                <div className="content__container">
                     <h2>The Project</h2>
                     <p>
                         Vermont Connector has launched the Baby & Child Product Exchange in partnership with twenty-five social services and mutual aid

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -135,28 +135,28 @@ export default function About() {
 
     return (
         <>
-            <div className="page--container">
+            <div className="page--header">
                 <h1>About</h1>
-                <div className="content--container">
-                    <h2>The Project</h2>
-                    <p>
-                        Vermont Connector has launched the Baby & Child Product Exchange in partnership with twenty-five social services and mutual aid
-                        organizations{' '}
-                    </p>
-                    <p>The exchange provides durable equipment to families in need through partner referrals and community donations.</p>
-                    <h4 className={styles['about__heading']}>Learn More:</h4>
-                    <p className={styles['about__paragraph']}>
-                        <a href="https://www.wendyriceconsulting.com/">Click here for Vermont Connector&apos;s project page</a>
-                    </p>
-                    <br />
-                    <h2>Donations</h2>
-                    <p className={styles['about__paragraph--list-label']}>List of item accepted:</p>
-                    <ul className={styles['about__list']}>{itemTypesAcceptedList}</ul>
-                    <p className={styles['about__paragraph--list-label']}>List of items not accepted:</p>
-                    <ul className={styles['about__list']}>{itemTypesNotAcceptedList}</ul>
-                    <p>Read the full FAQ documents.</p>
-                    <ul className={styles['about__list']}>{faqList}</ul>
-                </div>
+            </div>
+            <div className="content--container">
+                <h2>The Project</h2>
+                <p>
+                    Vermont Connector has launched the Baby & Child Product Exchange in partnership with twenty-five social services and mutual aid
+                    organizations{' '}
+                </p>
+                <p>The exchange provides durable equipment to families in need through partner referrals and community donations.</p>
+                <h4 className={styles['about__heading']}>Learn More:</h4>
+                <p className={styles['about__paragraph']}>
+                    <a href="https://www.wendyriceconsulting.com/">Click here for Vermont Connector&apos;s project page</a>
+                </p>
+                <br />
+                <h2>Donations</h2>
+                <p className={styles['about__paragraph--list-label']}>List of item accepted:</p>
+                <ul className={styles['about__list']}>{itemTypesAcceptedList}</ul>
+                <p className={styles['about__paragraph--list-label']}>List of items not accepted:</p>
+                <ul className={styles['about__list']}>{itemTypesNotAcceptedList}</ul>
+                <p>Read the full FAQ documents.</p>
+                <ul className={styles['about__list']}>{faqList}</ul>
             </div>
         </>
     );

--- a/src/app/account/edit/page.tsx
+++ b/src/app/account/edit/page.tsx
@@ -13,7 +13,7 @@ import { getUserAccount, setUserAccount } from '@/api/firebase-users';
 //Models
 import { AccountInformation as AccountInfo } from '@/types/post-data';
 //Styling
-import globalStyles from '@/styles/globalStyles.module.scss';
+import '../../../styles/globalStyles.css';
 import styles from './AccountEdit.module.css';
 
 type AccountFormData = {
@@ -136,7 +136,7 @@ export default function EditAccount() {
         <ProtectedRoute>
             <Box className={styles['account__container']}>
                 <h1>Edit Account</h1>
-                <Box display={'flex'} justifyContent="space-evenly" className={globalStyles['content__container']}>
+                <Box display={'flex'} justifyContent="space-evenly" className="content__container">
                     <Paper component={Box} flexDirection={'column'} className={styles['account__header']}>
                         <h4>
                             {formData.name} ({accountType})

--- a/src/app/account/edit/page.tsx
+++ b/src/app/account/edit/page.tsx
@@ -134,86 +134,86 @@ export default function EditAccount() {
 
     return (
         <ProtectedRoute>
-            <Box className={styles['account__container']}>
+            <div className="page--header">
                 <h1>Edit Account</h1>
-                <Box display={'flex'} justifyContent="space-evenly" className="content__container">
-                    <Paper component={Box} flexDirection={'column'} className={styles['account__header']}>
-                        <h4>
-                            {formData.name} ({accountType})
-                        </h4>
-                    </Paper>
-                    <Box component="form" className={styles['form']} id="editAccount" onSubmit={handleFormSubmit}>
-                        <Box className={styles['form__section--right']} display={'flex'} flexDirection={'column'} gap={3}>
-                            <Divider textAlign="center">Contact</Divider>
-                            <TextField
-                                type="email"
-                                label="Email"
-                                placeholder="Input email"
-                                name="contactEmail"
-                                id="contactEmail"
-                                onChange={handleInputChange}
-                                value={formData.contactEmail ? formData.contactEmail : ''}
-                                variant="standard"
-                            />
-                            <TextField
-                                type="tel"
-                                label="Phone Number"
-                                name="contactPhone"
-                                id="contactPhone"
-                                onChange={handleInputChange}
-                                value={formData.contactPhone ? formData.contactPhone : ''}
-                                variant="standard"
-                            />
-                        </Box>
-                        <Box className={styles['form__section--left']} display={'flex'} flexDirection={'column'} gap={1}>
-                            <Divider textAlign="center">Location</Divider>
-                            <TextField
-                                type="text"
-                                placeholder="input address"
-                                label="Street Address"
-                                name="locationStreet"
-                                id="locationStreet"
-                                onChange={handleInputChange}
-                                value={formData.locationStreet ? formData.locationStreet : ''}
-                                variant="standard"
-                            />
-                            <TextField
-                                type="text"
-                                placeholder="input city"
-                                label="City"
-                                name="locationCity"
-                                id="locationCity"
-                                onChange={handleInputChange}
-                                value={formData.locationCity ? formData.locationCity : ''}
-                                variant="standard"
-                            />
-                            <TextField
-                                label="State"
-                                placeholder="input state"
-                                type="text"
-                                name="locationState"
-                                id="locationState"
-                                onChange={handleInputChange}
-                                value={formData.locationState ? formData.locationState : ''}
-                                variant="standard"
-                            />
-                            <TextField
-                                label="Zip Code"
-                                placeholder="input zip code"
-                                type="text"
-                                name="locationZip"
-                                id="locationZip"
-                                onChange={handleInputChange}
-                                value={formData.locationZip ? formData.locationZip : ''}
-                                variant="standard"
-                            />
-                        </Box>
-                        <div className={styles['form__section--button-bottom']}>
-                            <Button variant="contained" type={'submit'} endIcon={<PermIdentityOutlinedIcon />}>
-                                Save
-                            </Button>
-                        </div>
+            </div>
+            <Box display={'flex'} justifyContent="space-evenly" className="content--container">
+                <Paper component={Box} flexDirection={'column'} className={styles['account__header']}>
+                    <h4>
+                        {formData.name} ({accountType})
+                    </h4>
+                </Paper>
+                <Box component="form" className={styles['form']} id="editAccount" onSubmit={handleFormSubmit}>
+                    <Box className={styles['form__section--right']} display={'flex'} flexDirection={'column'} gap={3}>
+                        <Divider textAlign="center">Contact</Divider>
+                        <TextField
+                            type="email"
+                            label="Email"
+                            placeholder="Input email"
+                            name="contactEmail"
+                            id="contactEmail"
+                            onChange={handleInputChange}
+                            value={formData.contactEmail ? formData.contactEmail : ''}
+                            variant="standard"
+                        />
+                        <TextField
+                            type="tel"
+                            label="Phone Number"
+                            name="contactPhone"
+                            id="contactPhone"
+                            onChange={handleInputChange}
+                            value={formData.contactPhone ? formData.contactPhone : ''}
+                            variant="standard"
+                        />
                     </Box>
+                    <Box className={styles['form__section--left']} display={'flex'} flexDirection={'column'} gap={1}>
+                        <Divider textAlign="center">Location</Divider>
+                        <TextField
+                            type="text"
+                            placeholder="input address"
+                            label="Street Address"
+                            name="locationStreet"
+                            id="locationStreet"
+                            onChange={handleInputChange}
+                            value={formData.locationStreet ? formData.locationStreet : ''}
+                            variant="standard"
+                        />
+                        <TextField
+                            type="text"
+                            placeholder="input city"
+                            label="City"
+                            name="locationCity"
+                            id="locationCity"
+                            onChange={handleInputChange}
+                            value={formData.locationCity ? formData.locationCity : ''}
+                            variant="standard"
+                        />
+                        <TextField
+                            label="State"
+                            placeholder="input state"
+                            type="text"
+                            name="locationState"
+                            id="locationState"
+                            onChange={handleInputChange}
+                            value={formData.locationState ? formData.locationState : ''}
+                            variant="standard"
+                        />
+                        <TextField
+                            label="Zip Code"
+                            placeholder="input zip code"
+                            type="text"
+                            name="locationZip"
+                            id="locationZip"
+                            onChange={handleInputChange}
+                            value={formData.locationZip ? formData.locationZip : ''}
+                            variant="standard"
+                        />
+                    </Box>
+                    <div className={styles['form__section--button-bottom']}>
+                        <Button variant="contained" type={'submit'} endIcon={<PermIdentityOutlinedIcon />}>
+                            Save
+                        </Button>
+                    </div>
                 </Box>
             </Box>
         </ProtectedRoute>

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -66,39 +66,39 @@ export default function Account() {
 
     return (
         <ProtectedRoute>
-            <div className={styles['account__container']}>
+            <div className="page--header">
                 <h1>Account</h1>
                 <h4>[Page Summary]</h4>
-                <div className="content__container">
-                    <div className={styles['account__header']}>
-                        <h2>Account Details</h2>
-                        <div>
-                            <Button component={Link} href="/account/edit" variant="contained" endIcon={<PermIdentityOutlinedIcon />}>
-                                Edit Profile
-                            </Button>
-                        </div>
+            </div>
+            <div className="content--container">
+                <div className={styles['account__header']}>
+                    <h2>Account Details</h2>
+                    <div>
+                        <Button component={Link} href="/account/edit" variant="contained" endIcon={<PermIdentityOutlinedIcon />}>
+                            Edit Profile
+                        </Button>
                     </div>
-                    <h4>Usertype: {accountType}</h4>
-                    <h4>Display name {accountInfo.contact?.name}</h4>
-                    <h4>
-                        Contact: <br />
-                        Phone: {accountInfo.contact?.phone}
-                        <br />
-                        Email: {accountInfo.contact?.email}
-                    </h4>
-                    <h4>
-                        Location: <br />
-                        {accountInfo.location?.line_1}
-                        <br />
-                        {accountInfo.location?.city} {accountInfo.location?.state}
-                        <br />
-                        {accountInfo.location?.zipcode}
-                        <br />
-                    </h4>
-
-                    <h2>Donations:</h2>
-                    <Browse />
                 </div>
+                <h4>Usertype: {accountType}</h4>
+                <h4>Display name {accountInfo.contact?.name}</h4>
+                <h4>
+                    Contact: <br />
+                    Phone: {accountInfo.contact?.phone}
+                    <br />
+                    Email: {accountInfo.contact?.email}
+                </h4>
+                <h4>
+                    Location: <br />
+                    {accountInfo.location?.line_1}
+                    <br />
+                    {accountInfo.location?.city} {accountInfo.location?.state}
+                    <br />
+                    {accountInfo.location?.zipcode}
+                    <br />
+                </h4>
+
+                <h2>Donations:</h2>
+                <Browse />
             </div>
         </ProtectedRoute>
     );

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -10,7 +10,7 @@ import { useUserContext } from '@/contexts/UserContext';
 //Models
 import { AccountInformation as AccountInfo } from '@/types/post-data';
 //Styling
-import globalStyles from '@/styles/globalStyles.module.scss';
+import '../../styles/globalStyles.css';
 import styles from './Account.module.css';
 import { getAccountType } from '@/api/firebase';
 import { getUserAccount } from '@/api/firebase-users';
@@ -69,7 +69,7 @@ export default function Account() {
             <div className={styles['account__container']}>
                 <h1>Account</h1>
                 <h4>[Page Summary]</h4>
-                <div className={globalStyles['content__container']}>
+                <div className="content__container">
                     <div className={styles['account__header']}>
                         <h2>Account Details</h2>
                         <div>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -26,73 +26,73 @@ export default function Contact() {
 
     return (
         <>
-            <div className="page--container">
+            <div className="page--header">
                 <h1>Contact</h1>
                 <h4>Send a message to the exchange administrators</h4>
-                <div className="content--container">
-                    <Box>
-                        <div className={styles['contact-details__container']}>
-                            <h4 className={styles['contact__heading']}>Address:</h4>
-                            <p className={styles['contact__paragraph']}>
-                                1205 North Ave
-                                <br />
-                                Burlington, VT 05408
-                            </p>
-                        </div>
-                        <div className={styles['contact-details__container']}>
-                            <h4 className={styles['contact__heading']}>Email:</h4>
-                            <p className={`${styles['contact__paragraph']} ${styles['contact__paragraph--email']}`}>vermontconnector@gmail.com</p>
-                        </div>
-                        <div className={styles['contact-details__container']}>
-                            <h4 className={styles['contact__heading']}>Appointments:</h4>
-                            <p className={styles['contact__paragraph']}>
-                                <a href="">Calendar</a>
-                            </p>
-                        </div>
-                    </Box>
-                    <Box component="form" gap={3} display={'flex'} flexDirection={'column'} onSubmit={() => {}}>
-                        <TextField
-                            required
-                            type="text"
-                            label="Contact Name"
-                            name="contactName"
-                            id="contactName"
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(e)}
-                            value={formData.contactName ? formData.contactName : ''}
-                        ></TextField>
-                        <TextField
-                            type="text"
-                            label="Email"
-                            name="email"
-                            id="email"
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(e)}
-                            value={formData.email ? formData.email : ''}
-                        ></TextField>
-                        <TextField
-                            type="text"
-                            label="Subject"
-                            name="subject"
-                            id="subject"
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(e)}
-                            value={formData.subject ? formData.subject : ''}
-                        ></TextField>
-                        <TextField
-                            multiline={true}
-                            name="message"
-                            label="Message"
-                            id="message"
-                            minRows={12}
-                            placeholder="Type your message here"
-                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(e)}
-                            value={formData.message ? formData.message : ''}
-                        ></TextField>
-                        <div className={styles['form__section--bottom']}>
-                            <Button variant="contained" type={'submit'} endIcon={<GroupsOutlinedIcon />}>
-                                Submit
-                            </Button>
-                        </div>
-                    </Box>
-                </div>
+            </div>
+            <div className="content--container">
+                <Box>
+                    <div className={styles['contact-details__container']}>
+                        <h4 className={styles['contact__heading']}>Address:</h4>
+                        <p className={styles['contact__paragraph']}>
+                            1205 North Ave
+                            <br />
+                            Burlington, VT 05408
+                        </p>
+                    </div>
+                    <div className={styles['contact-details__container']}>
+                        <h4 className={styles['contact__heading']}>Email:</h4>
+                        <p className={`${styles['contact__paragraph']} ${styles['contact__paragraph--email']}`}>vermontconnector@gmail.com</p>
+                    </div>
+                    <div className={styles['contact-details__container']}>
+                        <h4 className={styles['contact__heading']}>Appointments:</h4>
+                        <p className={styles['contact__paragraph']}>
+                            <a href="">Calendar</a>
+                        </p>
+                    </div>
+                </Box>
+                <Box component="form" gap={3} display={'flex'} flexDirection={'column'} onSubmit={() => {}}>
+                    <TextField
+                        required
+                        type="text"
+                        label="Contact Name"
+                        name="contactName"
+                        id="contactName"
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(e)}
+                        value={formData.contactName ? formData.contactName : ''}
+                    ></TextField>
+                    <TextField
+                        type="text"
+                        label="Email"
+                        name="email"
+                        id="email"
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(e)}
+                        value={formData.email ? formData.email : ''}
+                    ></TextField>
+                    <TextField
+                        type="text"
+                        label="Subject"
+                        name="subject"
+                        id="subject"
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(e)}
+                        value={formData.subject ? formData.subject : ''}
+                    ></TextField>
+                    <TextField
+                        multiline={true}
+                        name="message"
+                        label="Message"
+                        id="message"
+                        minRows={12}
+                        placeholder="Type your message here"
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(e)}
+                        value={formData.message ? formData.message : ''}
+                    ></TextField>
+                    <div className={styles['form__section--bottom']}>
+                        <Button variant="contained" type={'submit'} endIcon={<GroupsOutlinedIcon />}>
+                            Submit
+                        </Button>
+                    </div>
+                </Box>
             </div>
         </>
     );

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -5,7 +5,7 @@ import GroupsOutlinedIcon from '@mui/icons-material/GroupsOutlined';
 //Hooks
 import { useState } from 'react';
 //Styling
-import globalStyles from '@/styles/globalStyles.module.scss';
+import '../..//globalStyles.css';
 import styles from './Contact.module.css';
 
 type ContactFormData = {
@@ -29,7 +29,7 @@ export default function Contact() {
             <div className={styles['contact__container']}>
                 <h1>Contact</h1>
                 <h4>Send a message to the exchange administrators</h4>
-                <div className={globalStyles['content__container']}>
+                <div className="content__container">
                     <Box>
                         <div className={styles['contact-details__container']}>
                             <h4 className={styles['contact__heading']}>Address:</h4>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -5,7 +5,7 @@ import GroupsOutlinedIcon from '@mui/icons-material/GroupsOutlined';
 //Hooks
 import { useState } from 'react';
 //Styling
-import '../..//globalStyles.css';
+import '../../styles/globalStyles.css';
 import styles from './Contact.module.css';
 
 type ContactFormData = {
@@ -26,10 +26,10 @@ export default function Contact() {
 
     return (
         <>
-            <div className={styles['contact__container']}>
+            <div className="page--container">
                 <h1>Contact</h1>
                 <h4>Send a message to the exchange administrators</h4>
-                <div className="content__container">
+                <div className="content--container">
                     <Box>
                         <div className={styles['contact-details__container']}>
                             <h4 className={styles['contact__heading']}>Address:</h4>

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -11,7 +11,7 @@ import { useRouter } from 'next/navigation';
 import { useUserContext } from '@/contexts/UserContext';
 import { uploadImages } from '@/api/firebase-images';
 import { addDonation } from '@/api/firebase-donations';
-import globalStyles from '@/styles/globalStyles.module.scss';
+import '../../styles/globalStyles.css';
 import styles from './Donate.module.css';
 import { DocumentReference, doc } from 'firebase/firestore';
 import { USERS_COLLECTION } from '@/api/firebase-users';
@@ -138,7 +138,7 @@ export default function Donate() {
                             Safercar.gov (<a href="https://www.nhtsa.gov/campaign/safercargov?redirect-safercar-sitewide">safercar.gov</a>)
                         </li>
                     </ul>
-                    <div className={globalStyles['content__container']}>
+                    <div className="content__container">
                         <Box component="form" onSubmit={handleFormSubmit} method="POST" className={styles['form']}>
                             <Box className={styles['form__section--left']}>
                                 <Box display={'flex'} flexDirection={'column'} gap={1}>

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -115,29 +115,32 @@ export default function Donate() {
         <ProtectedRoute>
             {submitState === 'submitting' && <Loader />}
             {(submitState === 'idle' || submitState === 'error') && (
-                <div className="page--container">
-                    <h1>Donate</h1>
-                    <p>
-                        Vermont Connector does not have the capacity to verify recall and safety guidelines for each individual item donated. That said, we do
-                        not accept items that have stringent health or safety requirements (such as car seats, booster seats, breast pumps) or that could be
-                        subject to recall (such as cribs). We ask that donors only offer items that are clean, in good working order, and not subject to recall.
-                    </p>
-                    <p>Please reference the following web pages if you have any questions about safety/recall status of these items:</p>
-                    <ul>
-                        <li>
-                            Consumer Product Safety Commission (<a href="https://www.cpsc.gov/">cpsc.gov</a>)
-                        </li>
-                        <li>Reseller&apos;s Guide to Selling Safer Products</li>
-                        <li>
-                            SaferProducts.gov (<a href="https://www.saferproducts.gov">saferproducts.gov</a>)
-                        </li>
-                        <li>
-                            Recalls.gov (<a href="https://www.recalls.gov/">recalls.gov</a>)
-                        </li>
-                        <li>
-                            Safercar.gov (<a href="https://www.nhtsa.gov/campaign/safercargov?redirect-safercar-sitewide">safercar.gov</a>)
-                        </li>
-                    </ul>
+                <>
+                    <div className="page--header">
+                        <h1>Donate</h1>
+                        <p>
+                            Vermont Connector does not have the capacity to verify recall and safety guidelines for each individual item donated. That said, we
+                            do not accept items that have stringent health or safety requirements (such as car seats, booster seats, breast pumps) or that could
+                            be subject to recall (such as cribs). We ask that donors only offer items that are clean, in good working order, and not subject to
+                            recall.
+                        </p>
+                        <p>Please reference the following web pages if you have any questions about safety/recall status of these items:</p>
+                        <ul>
+                            <li>
+                                Consumer Product Safety Commission (<a href="https://www.cpsc.gov/">cpsc.gov</a>)
+                            </li>
+                            <li>Reseller&apos;s Guide to Selling Safer Products</li>
+                            <li>
+                                SaferProducts.gov (<a href="https://www.saferproducts.gov">saferproducts.gov</a>)
+                            </li>
+                            <li>
+                                Recalls.gov (<a href="https://www.recalls.gov/">recalls.gov</a>)
+                            </li>
+                            <li>
+                                Safercar.gov (<a href="https://www.nhtsa.gov/campaign/safercargov?redirect-safercar-sitewide">safercar.gov</a>)
+                            </li>
+                        </ul>
+                    </div>
                     <div className="content--container">
                         <Box component="form" onSubmit={handleFormSubmit} method="POST" className={styles['form']}>
                             <Box className={styles['form__section--left']}>
@@ -220,7 +223,7 @@ export default function Donate() {
                             </Box>
                         </Box>
                     </div>
-                </div>
+                </>
             )}
             {submitState === 'error' && <ToasterNotification status="Submission failed" />}
         </ProtectedRoute>

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -115,7 +115,7 @@ export default function Donate() {
         <ProtectedRoute>
             {submitState === 'submitting' && <Loader />}
             {(submitState === 'idle' || submitState === 'error') && (
-                <div className={styles['donate__container']}>
+                <div className="page--container">
                     <h1>Donate</h1>
                     <p>
                         Vermont Connector does not have the capacity to verify recall and safety guidelines for each individual item donated. That said, we do
@@ -138,7 +138,7 @@ export default function Donate() {
                             Safercar.gov (<a href="https://www.nhtsa.gov/campaign/safercargov?redirect-safercar-sitewide">safercar.gov</a>)
                         </li>
                     </ul>
-                    <div className="content__container">
+                    <div className="content--container">
                         <Box component="form" onSubmit={handleFormSubmit} method="POST" className={styles['form']}>
                             <Box className={styles['form__section--left']}>
                                 <Box display={'flex'} flexDirection={'column'} gap={1}>

--- a/src/app/donations/[id]/page.tsx
+++ b/src/app/donations/[id]/page.tsx
@@ -40,7 +40,7 @@ export default function DonationDetails({ params }: { params: { id: string } }) 
     if (!isLoading && donationDetails !== null) {
         const donation = donationDetails.donation;
         return (
-            <div className="page--container">
+            <div className="page--header">
                 <h1>Donation Details</h1>
                 <div className="content--container">
                     <h2>{donation.brand}</h2>

--- a/src/app/donations/[id]/page.tsx
+++ b/src/app/donations/[id]/page.tsx
@@ -40,10 +40,12 @@ export default function DonationDetails({ params }: { params: { id: string } }) 
     if (!isLoading && donationDetails !== null) {
         const donation = donationDetails.donation;
         return (
-            <div>
+            <div className="page--container">
                 <h1>Donation Details</h1>
-                <h2>{donation.brand}</h2>
-                <h3>{donation.model}</h3>
+                <div className="content--container">
+                    <h2>{donation.brand}</h2>
+                    <h3>{donation.model}</h3>
+                </div>
             </div>
         );
     }

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -71,7 +71,7 @@ export default function NewAccount() {
 
     return (
         <>
-            <div>
+            <div className="page--container">
                 <h1>Join</h1>
                 <Alert severity="warning">The Join page and account creation features have been deprecated.</Alert>
                 <Paper className="content__container" elevation={8} square={false}>

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/navigation';
 //Libs
 import { addEvent, auth, isEmailInvalid, onAuthStateChangedListener } from '@/api/firebase';
 //Styling
-import globalStyles from '@/styles/globalStyles.module.scss';
+import '../../styles/globalStyles.css';
 import { UserBody } from '@/types/post-data';
 import Loader from '@/components/Loader';
 import { createUserWithEmailAndPassword } from 'firebase/auth';
@@ -74,7 +74,7 @@ export default function NewAccount() {
             <div>
                 <h1>Join</h1>
                 <Alert severity="warning">The Join page and account creation features have been deprecated.</Alert>
-                <Paper className={globalStyles['content__container']} elevation={8} square={false}>
+                <Paper className="content__container" elevation={8} square={false}>
                     {loginState === 'pending' && <Loader />}
                     {loginState === 'loggedOut' && (
                         <>

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -71,75 +71,75 @@ export default function NewAccount() {
 
     return (
         <>
-            <div className="page--container">
+            <div className="page--header">
                 <h1>Join</h1>
                 <Alert severity="warning">The Join page and account creation features have been deprecated.</Alert>
-                <Paper className="content__container" elevation={8} square={false}>
-                    {loginState === 'pending' && <Loader />}
-                    {loginState === 'loggedOut' && (
-                        <>
-                            <Box component="form" gap={3} display={'flex'} flexDirection={'column'} onSubmit={handleAccountCreate}>
-                                <TextField
-                                    type="text"
-                                    label="Display Name"
-                                    name="displayName"
-                                    id="displayName"
-                                    placeholder="Provide a display name"
-                                    onChange={(event: React.ChangeEvent<HTMLInputElement>): void => {
-                                        setDisplayName(event.target.value);
-                                    }}
-                                    value={displayName}
-                                    required
-                                />
-                                <TextField
-                                    type="text"
-                                    label="Email"
-                                    name="email"
-                                    id="email"
-                                    placeholder="Input email"
-                                    autoComplete="email"
-                                    value={email}
-                                    error={emailInvalid}
-                                    helperText={emailInvalid ? 'Invalid email.' : undefined}
-                                    required
-                                    inputProps={{
-                                        onBlur: handleEmailInput
-                                    }}
-                                    onChange={(event: React.ChangeEvent<HTMLInputElement>): void => {
-                                        setEmail(event.target.value);
-                                    }}
-                                />
-                                <TextField
-                                    type="password"
-                                    label="Password"
-                                    name="password"
-                                    id="password"
-                                    placeholder="Input password"
-                                    autoComplete="current-password"
-                                    value={password}
-                                    required
-                                    onChange={handlePassword}
-                                />
-                                <TextField
-                                    type="password"
-                                    label="Confirm Password"
-                                    name="confirmPassword"
-                                    id="confirmPassword"
-                                    placeholder="Confirm password"
-                                    value={confirmPassword}
-                                    error={passwordsDoNotMatch}
-                                    helperText={passwordsDoNotMatch ? 'Passwords do not match.' : undefined}
-                                    required
-                                    onChange={handleConfirmPassword}
-                                />
-                                <Button variant="contained" type={'submit'} disabled={emailInvalid || passwordsDoNotMatch}>
-                                    Join
-                                </Button>
-                            </Box>
-                        </>
-                    )}
-                </Paper>
             </div>
+            <Paper className="content--container" elevation={8} square={false}>
+                {loginState === 'pending' && <Loader />}
+                {loginState === 'loggedOut' && (
+                    <>
+                        <Box component="form" gap={3} display={'flex'} flexDirection={'column'} onSubmit={handleAccountCreate}>
+                            <TextField
+                                type="text"
+                                label="Display Name"
+                                name="displayName"
+                                id="displayName"
+                                placeholder="Provide a display name"
+                                onChange={(event: React.ChangeEvent<HTMLInputElement>): void => {
+                                    setDisplayName(event.target.value);
+                                }}
+                                value={displayName}
+                                required
+                            />
+                            <TextField
+                                type="text"
+                                label="Email"
+                                name="email"
+                                id="email"
+                                placeholder="Input email"
+                                autoComplete="email"
+                                value={email}
+                                error={emailInvalid}
+                                helperText={emailInvalid ? 'Invalid email.' : undefined}
+                                required
+                                inputProps={{
+                                    onBlur: handleEmailInput
+                                }}
+                                onChange={(event: React.ChangeEvent<HTMLInputElement>): void => {
+                                    setEmail(event.target.value);
+                                }}
+                            />
+                            <TextField
+                                type="password"
+                                label="Password"
+                                name="password"
+                                id="password"
+                                placeholder="Input password"
+                                autoComplete="current-password"
+                                value={password}
+                                required
+                                onChange={handlePassword}
+                            />
+                            <TextField
+                                type="password"
+                                label="Confirm Password"
+                                name="confirmPassword"
+                                id="confirmPassword"
+                                placeholder="Confirm password"
+                                value={confirmPassword}
+                                error={passwordsDoNotMatch}
+                                helperText={passwordsDoNotMatch ? 'Passwords do not match.' : undefined}
+                                required
+                                onChange={handleConfirmPassword}
+                            />
+                            <Button variant="contained" type={'submit'} disabled={emailInvalid || passwordsDoNotMatch}>
+                                Join
+                            </Button>
+                        </Box>
+                    </>
+                )}
+            </Paper>
         </>
     );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,15 +7,15 @@ import { montserrat, garamond } from '../styles/fonts';
 //Providers
 import { UserProvider } from '@/contexts/UserContext';
 //Styles
-import globalStyles from '@/styles/globalStyles.module.scss';
+import '../styles/globalStyles.css';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
         <html lang="en" className={`${montserrat.variable} ${garamond.variable}`}>
-            <body className={globalStyles['body--wrapper']}>
+            <body className="body--wrapper">
                 <UserProvider>
                     <Header />
-                    <div className={globalStyles['page--wrapper']}>{children}</div>
+                    <div className="page--wrapper">{children}</div>
                     <Footer />
                 </UserProvider>
             </body>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -41,50 +41,51 @@ export default function Login() {
 
     return (
         <>
-            <div className="page-container">
+            <div className="page--header">
                 <h1>Login</h1>
                 <h4>[Page Summary]</h4>
-                <div className="content--container">
-                    {loginState === 'pending' && <Loader />}
-                    {loginState === 'loggedOut' && (
-                        <>
-                            <Box component="form" gap={3} display={'flex'} flexDirection={'column'} onSubmit={handleLogin}>
-                                <TextField
-                                    type="text"
-                                    name="email"
-                                    id="email"
-                                    label="Email"
-                                    placeholder="Input Email"
-                                    autoComplete="email"
-                                    value={email}
-                                    required
-                                    onChange={(event: React.ChangeEvent<HTMLInputElement>): void => {
-                                        setEmail(event.target.value);
-                                    }}
-                                />
-                                <TextField
-                                    type="password"
-                                    name="password"
-                                    id="password"
-                                    label="Password"
-                                    placeholder="Input Password"
-                                    autoComplete="current-password"
-                                    value={password}
-                                    required
-                                    onChange={(event: React.ChangeEvent<HTMLInputElement>): void => {
-                                        setPassword(event.target.value);
-                                    }}
-                                />
-                                <Button variant="contained" type="submit" endIcon={<VpnKeyOutlinedIcon />}>
-                                    Login
-                                </Button>
-                            </Box>
-                            <hr />
-                            <span>Instructions for forgotten password.</span>
-                        </>
-                    )}
-                </div>
             </div>
+            <div className="content--container">
+                {loginState === 'pending' && <Loader />}
+                {loginState === 'loggedOut' && (
+                    <>
+                        <Box component="form" gap={3} display={'flex'} flexDirection={'column'} onSubmit={handleLogin}>
+                            <TextField
+                                type="text"
+                                name="email"
+                                id="email"
+                                label="Email"
+                                placeholder="Input Email"
+                                autoComplete="email"
+                                value={email}
+                                required
+                                onChange={(event: React.ChangeEvent<HTMLInputElement>): void => {
+                                    setEmail(event.target.value);
+                                }}
+                            />
+                            <TextField
+                                type="password"
+                                name="password"
+                                id="password"
+                                label="Password"
+                                placeholder="Input Password"
+                                autoComplete="current-password"
+                                value={password}
+                                required
+                                onChange={(event: React.ChangeEvent<HTMLInputElement>): void => {
+                                    setPassword(event.target.value);
+                                }}
+                            />
+                            <Button variant="contained" type="submit" endIcon={<VpnKeyOutlinedIcon />}>
+                                Login
+                            </Button>
+                        </Box>
+                        <hr />
+                        <span>Instructions for forgotten password.</span>
+                    </>
+                )}
+            </div>
+
             {status && <ToasterNotification status={status} />}
         </>
     );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -11,7 +11,7 @@ import { useSearchParams, useRouter } from 'next/navigation';
 //Libs
 import { signInAuthUserWithEmailAndPassword, onAuthStateChangedListener } from '@/api/firebase';
 //Styling
-import globalStyles from '@/styles/globalStyles.module.scss';
+import '../../styles/globalStyles.css';
 import styles from './Login.module.css';
 
 export default function Login() {
@@ -44,7 +44,7 @@ export default function Login() {
             <div className={styles['login__container']}>
                 <h1>Login</h1>
                 <h4>[Page Summary]</h4>
-                <div className={globalStyles['content__container']}>
+                <div className="content__container">
                     {loginState === 'pending' && <Loader />}
                     {loginState === 'loggedOut' && (
                         <>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -41,10 +41,10 @@ export default function Login() {
 
     return (
         <>
-            <div className={styles['login__container']}>
+            <div className="page-container">
                 <h1>Login</h1>
                 <h4>[Page Summary]</h4>
-                <div className="content__container">
+                <div className="content--container">
                     {loginState === 'pending' && <Loader />}
                     {loginState === 'loggedOut' && (
                         <>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,13 +28,13 @@ export default function Home() {
     const content = currentUser ? <Dashboard /> : loginElement;
     return (
         <ProtectedRoute>
-            <div className="page--container">
+            <div className="page--header">
                 <h1>Browse</h1>
                 <h4>[Page Summary]</h4>
-                <Paper className="content--container" elevation={8} square={false}>
-                    {content}
-                </Paper>
             </div>
+            <Paper className="content--container" elevation={8} square={false}>
+                {content}
+            </Paper>
         </ProtectedRoute>
     );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import React, { useContext } from 'react';
 
 //Styles
 import styles from './HomeStyles.module.css';
-import globalStyles from '@/styles/globalStyles.module.scss';
+import '../styles/globalStyles.css';
 import { Button } from '@mui/material';
 import VpnKeyOutlinedIcon from '@mui/icons-material/VpnKeyOutlined';
 //Hooks
@@ -31,7 +31,7 @@ export default function Home() {
             <div className={styles['home__container']}>
                 <h1>Browse</h1>
                 <h4>[Page Summary]</h4>
-                <Paper className={globalStyles['content__container']} elevation={8} square={false}>
+                <Paper className="content__container" elevation={8} square={false}>
                     {content}
                 </Paper>
             </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,10 +28,10 @@ export default function Home() {
     const content = currentUser ? <Dashboard /> : loginElement;
     return (
         <ProtectedRoute>
-            <div className={styles['home__container']}>
+            <div className="page--container">
                 <h1>Browse</h1>
                 <h4>[Page Summary]</h4>
-                <Paper className="content__container" elevation={8} square={false}>
+                <Paper className="content--container" elevation={8} square={false}>
                     {content}
                 </Paper>
             </div>

--- a/src/components/Browse.tsx
+++ b/src/components/Browse.tsx
@@ -20,6 +20,7 @@ import { addEvent } from '@/api/firebase';
 import algoliasearch from 'algoliasearch/lite';
 import { InstantSearch } from 'react-instantsearch';
 // Styles
+import '../styles/globalStyles.css';
 import styles from './Browse.module.css';
 
 const NewDonationDialog = lazy(() => import('@/components/NewDonationDialog'));

--- a/src/components/NavMenu.module.css
+++ b/src/components/NavMenu.module.css
@@ -1,10 +1,14 @@
 .menu__link {
-    font-family: var(--primary-font);
     color: white;
     padding: 0.5rem 0;
     font-size: 1.25rem;
     text-decoration: none;
     text-transform: uppercase;
+}
+
+.menu__link span {
+    font-family: var(--primary-font);
+    font-weight: 400;
 }
 
 .nav__menu {

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -36,23 +36,23 @@ export default function NavMenu({ isOpen, handleIsOpen, closeMenu }: Props) {
                 </button>
                 <div className={styles['nav__menu']}>
                     <Link className={styles['menu__link']} id="home" href="/" onClick={closeMenu}>
-                        Home
+                        <span>Home</span>
                     </Link>
                     {currentUser && (
                         <>
                             <Link className={styles['menu__link']} id="donate" href="/donate" onClick={closeMenu}>
-                                <ListItemText primary="Donate" />
+                                <span>Donate</span>
                             </Link>
                             <Link className={styles['menu__link']} id="account" href="/account" onClick={closeMenu}>
-                                Account
+                                <span>Account</span>
                             </Link>
                         </>
                     )}
                     <Link className={styles['menu__link']} id="about" href="/about" onClick={closeMenu}>
-                        About
+                        <span>About</span>
                     </Link>
                     <Link className={styles['menu__link']} id="contact" href="/contact" onClick={closeMenu}>
-                        Contact
+                        <span>Contact</span>
                     </Link>
                     <Link
                         className={styles['menu__link']}
@@ -63,7 +63,7 @@ export default function NavMenu({ isOpen, handleIsOpen, closeMenu }: Props) {
                             if (currentUser) signOutUser();
                         }}
                     >
-                        {currentUser ? 'Sign Out' : 'Login'}
+                        {currentUser ? <span>Sign Out</span> : <span>Login</span>}
                     </Link>
                 </div>
             </Drawer>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import { Suspense, useEffect } from 'react';
 import { useUserContext } from '@/contexts/UserContext';
 //Styling
-import globalStyles from '@/styles/globalStyles.module.scss';
+import '../styles/globalStyles.css';
 
 export default function ProtectedRoute({ children }: { children: React.ReactNode }) {
     const { currentUser, isLoading } = useUserContext();
@@ -20,7 +20,7 @@ export default function ProtectedRoute({ children }: { children: React.ReactNode
 
     if (isLoading) {
         return (
-            <div className={globalStyles['content__container']}>
+            <div className="content__container">
                 <Loader />
             </div>
         );

--- a/src/styles/globalStyles.css
+++ b/src/styles/globalStyles.css
@@ -11,6 +11,7 @@
     --footer: #1f1f1f;
     --primary-font: 'Graphik', 'EB Garamond', serif;
     --font-montserrat: 'Montserrat', 'Arial', sans-serif;
+    --adobe-garamond-pro: 'Adobe Garamond Pro', 'Garamond', serif;
     --button-dark: black;
     --button-light: white;
     --webkit-font-smoothing: subpixel-antialiased;
@@ -27,7 +28,7 @@
 }
 
 .body--wrapper * {
-    font-family: 'adobe-garamond-pro';
+    font-family: var(--adobe-garamond-pro);
     box-sizing: border-box;
 }
 
@@ -36,7 +37,7 @@
 }
 
 .body--wrapper * .MuiTypography-root {
-    font-family: 'adobe-garamond-pro';
+    font-family: var(--adobe-garamond-pro);
 }
 
 .body--wrapper h1,
@@ -45,7 +46,7 @@
 .body--wrapper h4,
 .body--wrapper h5,
 .body--wrapper h6 {
-    font-family: 'proxima-nova';
+    font-family: var(--primary-font);
 }
 
 .body--wrapper h1 {
@@ -82,17 +83,21 @@
 
 .body--wrapper p,
 .body--wrapper footer {
-    font-family: 'adobe-garamond-pro';
+    font-family: var(--primary-font);
     font-weight: 600;
 }
 
+.body--wrapper li {
+    font-family: var(--primary-font);
+    font-weight: 400;
+}
+
 .page--wrapper {
-    padding: 2px 10px;
+    box-sizing: border-box;
     font-family: var(--primary-font);
 }
 
-.page--container {
-    box-sizing: border-box;
+.page--header {
     width: 100%;
     padding: 1rem;
 }
@@ -101,6 +106,7 @@
     width: 100%;
     background-color: var(--bg-gray);
     margin: 0px auto;
+    padding: 1rem;
 }
 
 .body--wrapper a,

--- a/src/styles/globalStyles.css
+++ b/src/styles/globalStyles.css
@@ -9,6 +9,7 @@
     --error: #a8351b;
     --footer: #1f1f1f;
     --primary-font: 'Graphik', 'EB Garamond', serif;
+    --font-montserrat: 'Montserrat', 'Arial', sans-serif;
     --button-dark: black;
     --button-light: white;
     --webkit-font-smoothing: subpixel-antialiased;
@@ -89,12 +90,16 @@
     font-family: var(--primary-font);
 }
 
-.content__container {
+.page--container {
     box-sizing: border-box;
+    width: 100%;
+    padding: 1rem;
+}
+
+.content--container {
     width: 100%;
     background-color: var(--bg-gray);
     margin: 0px auto;
-    padding: 1rem;
 }
 
 .body--wrapper a,

--- a/src/styles/globalStyles.css
+++ b/src/styles/globalStyles.css
@@ -1,24 +1,23 @@
-@use 'sass:map';
-$palette: (
-    text-header: #a8351b,
-    primary: #fff,
-    secondary: #95b8b5,
-    text-body: #5e5e5e,
-    text-hyperlink: #3d9991,
-    text-visited: #000,
-    error: #a8351b,
-    footer: #1f1f1f
-);
-
-/* Variables and global styling */
-.body--wrapper {
+/* variables */
+:root {
+    --text-header: #a8351b;
+    --primary: #fff;
+    --secondary: #95b8b5;
+    --text-body: #5e5e5e;
+    --text-hyperlink: #3d9991;
+    --text-visited: #000;
+    --error: #a8351b;
+    --footer: #1f1f1f;
     --primary-font: 'Graphik', 'EB Garamond', serif;
     --button-dark: black;
     --button-light: white;
+    --webkit-font-smoothing: subpixel-antialiased;
+}
+
+.body--wrapper {
     -ms-text-size-adjust: 100%;
     -webkit-text-size-adjust: 100%;
     -moz-osx-font-smoothing: auto;
-    --webkit-font-smoothing: subpixel-antialiased;
     display: grid;
     grid-template: max-content 1fr max-content / 1fr;
     min-height: 100vh;
@@ -26,15 +25,16 @@ $palette: (
 }
 
 .body--wrapper * {
-    &.MuiTypography-root {
-        font-family: 'adobe-garamond-pro';
-    }
-
     font-family: 'adobe-garamond-pro';
     box-sizing: border-box;
-    &[class*='MuiInput'] {
-        box-sizing: content-box;
-    }
+}
+
+.body--wrapper *[class*='MuiInput'] {
+    box-sizing: content-box;
+}
+
+.body--wrapper * .MuiTypography-root {
+    font-family: 'adobe-garamond-pro';
 }
 
 .body--wrapper h1,
@@ -80,7 +80,7 @@ $palette: (
 
 .body--wrapper p,
 .body--wrapper footer {
-    font-family: var(--adobe-garamond-pro);
+    font-family: 'adobe-garamond-pro';
     font-weight: 600;
 }
 
@@ -92,14 +92,14 @@ $palette: (
 .content__container {
     box-sizing: border-box;
     width: 100%;
-    background-color: var(--bg-grey);
+    background-color: var(--bg-gray);
     margin: 0px auto;
     padding: 1rem;
 }
 
 .body--wrapper a,
 .body--wrapper a:visited {
-    color: map.get($palette, 'text-visited');
+    color: var(--text-visited);
 }
 
 .formContainer {
@@ -109,14 +109,13 @@ $palette: (
     margin: '30px auto';
 }
 
-.body--wrapper a {
-    &:hover {
-        color: map.get($palette, 'text-hyperlink');
-    }
-    &[class*='MuiButton'],
-    &:visited[class*='MuiButton'] {
-        color: white;
-    }
+.body--wrapper a:hover {
+    color: var(--text-hyperlink);
+}
+
+.body--wrapper a[class*='MuiButton'],
+.body--wrapper a:visited[class*='MuiButton'] {
+    color: white;
 }
 
 .MuiFilledInput-root {
@@ -125,16 +124,16 @@ $palette: (
     background-color: '#F3F6F9';
     border: '1px solid';
     border-color: '#E0E3E7';
+}
 
-    &:hover {
-        background-color: 'transparent';
-    }
+.MuiFilledInput-root:hover {
+    background-color: 'transparent';
+}
 
-    &.Mui-focused {
-        background-color: 'transparent';
-        box-shadow: 0 1px 6px '#E0E3E7';
-        border-color: '#E0E3E7';
-    }
+.MuiFilledInput-root.Mui-focused {
+    background-color: 'transparent';
+    box-shadow: 0 1px 6px '#E0E3E7';
+    border-color: '#E0E3E7';
 }
 
 .TextField {

--- a/src/styles/globalStyles.css
+++ b/src/styles/globalStyles.css
@@ -3,6 +3,7 @@
     --text-header: #a8351b;
     --primary: #fff;
     --secondary: #95b8b5;
+    --bg-gray: #f1f1f1;
     --text-body: #5e5e5e;
     --text-hyperlink: #3d9991;
     --text-visited: #000;


### PR DESCRIPTION
This PR replaces globalStyles.module.scss with a CSS file to avoid recurring dependency issues with Sass. Because you cannot use impure selectors such as ":root" in CSS modules, the globalStyles are a standard CSS file to allow for the use of variables. All existing CSS modules can now use these global variables as well using the 'attribute: var(--variable-name)' syntax.

**package.json
- remove sass as dependency

** various pages
- All globalStyles imports have been updated from "import globalStyles from '<filepath>'" to "import '<filepath>'"
- classNames have been updated as necessary to reference classes in new globalStyles.

** misc
- Added a 'page--header' class to globalStyles. Pages were previously referencing non-existent container classes specific to each page. 
- Added a gray background color variable that was referred to but never created to match the wireframes. 
- Update global styles to actually use primary font. 