### PR TITLE
Only log errors from email checking if they are actually errors

### DIFF
--- a/src/api/firebaseAdmin.ts
+++ b/src/api/firebaseAdmin.ts
@@ -238,12 +238,12 @@ export const isEmailInUse = async (request: any) => {
             return false;
         }
     } catch (error: any) {
-        logger.error(error);
-        _addEvent({ location: 'isEmailInUse', error: error, data: request.data });
         if (error.code === 'auth/user-not-found') {
             return false;
         }
+
         if (error.code !== 'auth/invalid-email') {
+            logger.error(error);
             _addEvent({ location: 'isEmailInUse', error: error, data: request.data });
         }
     }


### PR DESCRIPTION
Previously, when the frontend sent a request during the join process to check if an email was currently in use, the backend would log every error returned. Email checking is handled by catching a specific error, so when all the "user doesn't exist" errors come through while checking the email, they are logged, which is wrong. Instead, errors should only be treated as errors if they are not one of the errors that we are expecting.

Before:
![image](https://github.com/user-attachments/assets/b5c0342e-f146-4b78-abcf-013a2b669de1)

After:
![image](https://github.com/user-attachments/assets/45b4efe1-e46e-4402-bd6c-f5949bbe1b53)
