### PR TITLE
fix: header no longer overlaps page content on mobile

### DIFF
--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -6,11 +6,12 @@
     align-items: center;
     padding: 1rem;
     z-index: 10;
+    background-color: var(--primary);
 }
 
 .header__primary {
     font-family: var(--primary-font);
-    background-color: var(--bg-grey);
+    background-color: var(--primary);
     height: 2.5rem;
     display: flex;
     align-items: center;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,27 +17,10 @@ export default function Header() {
     function handleIsOpen() {
         setIsOpen(!isOpen);
     }
+
     function closeMenu() {
         setIsOpen(false);
     }
-
-    useEffect(() => {
-        const headerTitle = document.getElementById('headerTitle')!;
-        if (window.scrollY > headerTitle.offsetHeight * 2) {
-            headerTitle.style.visibility = 'hidden';
-        }
-        const handleTitle = () => {
-            if (window.scrollY > headerTitle.offsetHeight * 2) {
-                headerTitle.style.visibility = 'hidden';
-            } else {
-                headerTitle.style.visibility = 'visible';
-            }
-        };
-        window.addEventListener('scroll', handleTitle);
-        return () => {
-            window.removeEventListener('scroll', handleTitle);
-        };
-    }, []);
 
     return (
         <div className={styles['header__wrapper']}>


### PR DESCRIPTION
Fixes #71.

Mobile:
![image](https://github.com/user-attachments/assets/fdd2e36b-3e2f-4202-91ec-370c22cfcb0d)

Desktop (not previously broken, but still looks ok):
![image](https://github.com/user-attachments/assets/8cd1c9fa-f1f9-4fc3-9853-88c0fe850b18)


Also, I noticed that previously, the CSS var `--bg-grey` was used, while the correct one defined in globalStyles.css was spelled as `--bg-gray`, but I didn't want `bg-gray` anyways, so I changed it to `--primary`.
