### PR TITLE
Comment out page summary

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -68,7 +68,7 @@ export default function Account() {
         <ProtectedRoute>
             <div className="page--header">
                 <h1>Account</h1>
-                <h4>[Page Summary]</h4>
+                {/* <h4>[Page Summary]</h4> */}
             </div>
             <div className="content--container">
                 <div className={styles['account__header']}>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -62,7 +62,7 @@ function LoginForm({ loginState, setLoginState, email, setEmail, password, setPa
         <>
             <div className="page--header">
                 <h1>Login</h1>
-                <h4>[Page Summary]</h4>
+                {/* <h4>[Page Summary]</h4> */}
             </div>
             <div className="content--container">
                 {loginState === 'pending' && <Loader />}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,7 +30,7 @@ export default function Home() {
         <ProtectedRoute>
             <div className="page--header">
                 <h1>Browse</h1>
-                <h4>[Page Summary]</h4>
+                {/* <h4>[Page Summary]</h4> */}
             </div>
             <Paper className="content--container" elevation={8} square={false}>
                 {content}


### PR DESCRIPTION
Removes all `[Page Summary]` placeholders until they are either filled or purged. Fixes #78, but perhaps it should stay open until we know if we are filling them out.