### PR TITLE
Omit cloud functions folder from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
         "types": ["node", "babel__generator", "react", "react-dom"]
     },
     "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src"],
-    "exclude": ["node_modules"]
+    "exclude": ["node_modules", "./functions"]
 }


### PR DESCRIPTION
This is an effort to prevent App Hosting from attempting to install dev dependencies during production build. 