### PR TITLE
feature(disable user): add support for enabling and disabling users.

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -67,6 +67,24 @@ export const createnewuser = onCall(async (request: CallableRequest): Promise<Us
     return Promise.reject(new HttpsError('unknown', 'An error occurred while trying to create a new user.'));
 });
 
+export const disableuser = onCall(async (request): Promise<void> => {
+    if (!request.auth) {
+        return Promise.reject(new HttpsError('unauthenticated', 'Must be signed in to disable user account.'));
+    }
+    if (request.auth && request.auth.token.admin != true) {
+        return Promise.reject(new HttpsError('permission-denied', 'Only admins can disable user accounts.'));
+    } else if (request.auth && request.auth.token.admin == true) {
+        const userId = request.data.userId;
+        if (!userId) {
+            return Promise.reject(new HttpsError('invalid-argument', 'Must provide a user Id to disable a user account.'));
+        } else {
+            auth.updateUser(userId, { disabled: true })
+                .then(() => console.log(`User ${userId} disabled`))
+                .catch((error) => Promise.reject(new HttpsError('invalid-argument', 'Unable to update user account.')));
+        }
+    }
+});
+
 export const enableuser = onCall(async (request): Promise<void> => {
     if (!request.auth) {
         return Promise.reject(new HttpsError('unauthenticated', 'Must be signed in to enable user account.'));

--- a/src/api/firebase-users.ts
+++ b/src/api/firebase-users.ts
@@ -154,6 +154,15 @@ export async function enableDbUser(uid: string): Promise<void> {
     }
 }
 
+export async function disableDbUser(uid: string): Promise<void> {
+    try {
+        const docRef = doc(db, USERS_COLLECTION, uid);
+        await updateDoc(docRef, { isDisabled: true });
+    } catch (error) {
+        addErrorEvent('Error disabling db User', error);
+    }
+}
+
 //returns Auth User and db User details combined
 export async function getUserDetails(uid: string): Promise<IUser> {
     try {

--- a/src/api/firebase.ts
+++ b/src/api/firebase.ts
@@ -24,6 +24,7 @@ export const auth = getAuth(app);
 //Cloud functions
 const functions = getFunctions(app);
 const createNewUser = httpsCallable(functions, 'createnewuser');
+const disableUser = httpsCallable(functions, 'disableuser');
 const enableUser = httpsCallable(functions, 'enableuser');
 const getOrganizationNames = httpsCallable(functions, 'getorganizationnames');
 const isEMailInUse = httpsCallable(functions, 'isemailinuse');
@@ -98,6 +99,14 @@ export async function callEnableUser(userId: string): Promise<void> {
         await enableUser({ userId: userId });
     } catch (error) {
         addErrorEvent('Could not enable user', error);
+    }
+}
+
+export async function callDisableUser(userId: string): Promise<void> {
+    try {
+        await disableUser({ userId: userId });
+    } catch (error) {
+        addErrorEvent('Could not disable user', error);
     }
 }
 

--- a/src/components/CustomConfirm.tsx
+++ b/src/components/CustomConfirm.tsx
@@ -1,0 +1,65 @@
+'use client';
+//Hooks
+import { useState } from 'react';
+//Components
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
+import CustomDialog from './CustomDialog';
+//Types
+import ProtectedAdminRoute from './ProtectedAdminRoute';
+
+type CustomConfirmProps = {
+    isOpen: boolean;
+    onClose: () => void;
+    onCancel: () => void;
+    onConfirm: () => Promise<void> | void;
+    title: string;
+    content: string;
+    successTitle: string;
+    successDialog?: string;
+};
+
+const CustomConfirm = (props: CustomConfirmProps) => {
+    const { isOpen, onClose, onCancel, onConfirm, title, content, successDialog, successTitle } = props;
+    const [isThisOpen, setIsThisOpen] = useState<boolean>(false);
+    const [isConfirming, setIsConfirming] = useState<boolean>(false);
+
+    const handleConfirm = async () => {
+        setIsConfirming(true);
+        try {
+            await onConfirm();
+            if (successDialog) {
+                setIsThisOpen(true);
+            } else {
+                onClose();
+            }
+        } catch (error) {
+            console.error('Action failed:', error);
+        } finally {
+            setIsConfirming(false);
+        }
+    };
+
+    return (
+        <ProtectedAdminRoute>
+            <>
+                <Dialog open={isOpen && !isThisOpen && !isConfirming} aria-labelledby="dialog-title" aria-describedby="dialog-description">
+                    <DialogTitle id="dialog-title">{title}</DialogTitle>
+                    <DialogContent>
+                        <DialogContentText id="dialog-description">{content}</DialogContentText>
+                        <DialogActions>
+                            <Button variant="contained" onClick={handleConfirm}>
+                                Confirm
+                            </Button>
+                            <Button variant="outlined" onClick={onCancel}>
+                                Cancel
+                            </Button>
+                        </DialogActions>
+                    </DialogContent>
+                </Dialog>
+                {successDialog && successTitle && <CustomDialog isOpen={isThisOpen} onClose={onClose} title={successTitle} content={successDialog} />}
+            </>
+        </ProtectedAdminRoute>
+    );
+};
+
+export default CustomConfirm;

--- a/src/components/DisableUser.tsx
+++ b/src/components/DisableUser.tsx
@@ -1,0 +1,56 @@
+'use client';
+//Hooks
+import { Dispatch, SetStateAction } from 'react';
+//Components
+import CustomConfirm from './CustomConfirm';
+//Api
+import { callDisableUser } from '@/api/firebase';
+import { disableDbUser } from '@/api/firebase-users';
+import sendMail from '@/api/nodemailer';
+import { addErrorEvent } from '@/api/firebase';
+//Email Templates
+import disableUser from '@/email-templates/disableUser';
+//Types
+import type { UserCollection } from '@/models/user';
+
+type DisableUserProps = {
+    isOpen: boolean;
+    onClose: () => void;
+    onCancel: () => void;
+    title: string;
+    user: UserCollection;
+    setIsLoading: Dispatch<SetStateAction<boolean>>;
+};
+
+const DisableUser = (props: DisableUserProps) => {
+    const { isOpen, onClose, onCancel, title, user, setIsLoading } = props;
+
+    const handleDisableUser = async (uid: string, userName: string, userEmail: string): Promise<void> => {
+        setIsLoading(true);
+        try {
+            await Promise.all([callDisableUser(uid), disableDbUser(uid)]);
+            const msg = disableUser(userEmail, userName);
+            await sendMail(msg);
+        } catch (error) {
+            addErrorEvent('Call disable user', error);
+            throw error;
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <CustomConfirm
+            isOpen={isOpen}
+            onClose={onClose}
+            onCancel={onCancel}
+            onConfirm={() => handleDisableUser(user.uid, user.displayName, user.email)}
+            title={title || "Disable user?"}
+            content={`This will disable the user "${user.displayName}." Are you sure?`}
+            successTitle="User disabled"
+            successDialog={`The user ${user.displayName} has been disabled.`}
+        />
+    );
+};
+
+export default DisableUser;

--- a/src/components/EditUser.tsx
+++ b/src/components/EditUser.tsx
@@ -10,6 +10,8 @@ import { enableDbUser, updateDbUser } from '@/api/firebase-users';
 import { Paper, Box, FormControl, Autocomplete, TextField, Button, FormLabel, RadioGroup, FormControlLabel, Radio, Typography } from '@mui/material';
 import Loader from '@/components/Loader';
 import CustomDialog from './CustomDialog';
+import DisableUser from './DisableUser';
+import EnableUser from './EnableUser';
 import ProtectedAdminRoute from './ProtectedAdminRoute';
 //Constants
 import userEnabled from '@/email-templates/userEnabled';
@@ -48,11 +50,16 @@ const EditUser = (props: EditUserProps) => {
     const [newTitle, setNewTitle] = useState<string>(title ?? '');
     const [role, setRole] = useState<string>(initialRole);
     const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
+    const [activeDialog, setActiveDialog] = useState<'' | 'enable' | 'disable'>('');
 
     const handleClose = () => {
         if (setUserDetailsUpdated) setUserDetailsUpdated(true);
-        setIsDialogOpen(false);
+        setActiveDialog('');
         setIsEditMode(false);
+    };
+
+    const handleCancel = () => {
+        setActiveDialog('');
     };
 
     //List of Org names, ids from Server
@@ -263,11 +270,27 @@ const EditUser = (props: EditUserProps) => {
                             <Button variant="outlined" type="button" onClick={() => setIsEditMode(false)}>
                                 Cancel
                             </Button>
+
+                            {!isDisabled && (
+                                <Button variant="outlined" color="error" type="button" sx={{ marginLeft: 'auto' }} onClick={() => setActiveDialog('disable')}>
+                                    Disable User
+                                </Button>
+                            )}
+                            {initialOrg && isDisabled && (
+                                <Button variant="outlined" type="button" sx={{ marginLeft: 'auto' }} onClick={() => setActiveDialog('enable')}>
+                                    Enable User
+                                </Button>
+                            )}
                         </Box>
                     </Box>
                 )}
             </Paper>
             <CustomDialog isOpen={isDialogOpen} onClose={handleClose} title="User updated" content={`The user ${newDisplayName} has been updated.`} />
+            {/* Dialog for disabling user */}
+            {activeDialog === 'disable' && (
+                <DisableUser isOpen={true} onClose={handleClose} onCancel={handleCancel} title="Disable user?" user={props.userDetails} setIsLoading={setIsLoading} />
+            )}
+            {activeDialog === 'enable' && <EnableUser isOpen={true} onClose={handleClose} onCancel={handleCancel} user={props.userDetails} setIsLoading={setIsLoading} />}
         </ProtectedAdminRoute>
     );
 };

--- a/src/components/EnableUser.tsx
+++ b/src/components/EnableUser.tsx
@@ -1,0 +1,55 @@
+'use client';
+//Hooks
+import { Dispatch, SetStateAction } from 'react';
+//Components
+import CustomConfirm from './CustomConfirm';
+//Api
+import { callEnableUser } from '@/api/firebase';
+import { enableDbUser } from '@/api/firebase-users';
+import sendMail from '@/api/nodemailer';
+import { addErrorEvent } from '@/api/firebase';
+//Email Templates
+import enableUser from '@/email-templates/enableUser';
+//Types
+import type { UserCollection } from '@/models/user';
+
+type EnableUserProps = {
+    isOpen: boolean;
+    onClose: () => void;
+    onCancel: () => void;
+    user: UserCollection;
+    setIsLoading: Dispatch<SetStateAction<boolean>>;
+};
+
+const EnableUser = (props: EnableUserProps) => {
+    const { isOpen, onClose, onCancel, user, setIsLoading } = props;
+
+    const handleEnableUser = async (uid: string, userName: string, userEmail: string) => {
+        setIsLoading(true);
+        try {
+            await Promise.all([callEnableUser(uid), enableDbUser(uid)]);
+            const msg = enableUser(userEmail, userName);
+            await sendMail(msg);
+        } catch (error) {
+            addErrorEvent('Call enable user', error);
+            throw error;
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <CustomConfirm
+            isOpen={isOpen}
+            onClose={onClose}
+            onCancel={onCancel}
+            onConfirm={() => handleEnableUser(user.uid, user.displayName, user.email)}
+            title="Enable user?"
+            content="This will enable the user. Are you sure?"
+            successTitle="User enabled"
+            successDialog={`The user ${user.displayName} has been enabled.`}
+        />
+    );
+};
+
+export default EnableUser;

--- a/src/email-templates/disableUser.ts
+++ b/src/email-templates/disableUser.ts
@@ -1,0 +1,11 @@
+import { emailSender, emailCc } from '@/data/emailSender';
+
+export default function disableUser(email: string, userName: string) {
+    return {
+        to: email,
+        cc: emailCc,
+        from: emailSender,
+        subject: 'Your Baby Product Exchange user account has been disabled',
+        html: `<p>Hello ${userName}</p><p>The user account you created for the Baby Product Exchange has been disabled.</"p><p>If you feel this was done in error, please email <a href="mailto:info@vermontconnector.org">info@vermontconnector.org</a></p><p>Thank you and have a great day.</p>`
+    };
+}

--- a/src/email-templates/enableUser.ts
+++ b/src/email-templates/enableUser.ts
@@ -1,0 +1,11 @@
+import { emailSender, emailCc } from '@/data/emailSender';
+
+export default function enableUser(email: string, userName: string) {
+    return {
+        to: email,
+        cc: emailCc,
+        from: emailSender,
+        subject: 'Your Baby Product Exchange user account has been enabled',
+        html: `<p>Hello ${userName}</p><p>The user account you created for the Baby Product Exchange has been enabled.</"p><p>If you feel this was done in error, please email <a href="mailto:info@vermontconnector.org">info@vermontconnector.org</a></p><p>Thank you and have a great day.</p>`
+    };
+}


### PR DESCRIPTION
## Add buttons to disable/re-enable users

Addresses [Add the ability for the admin to disable a user \#256
](https://github.com/codeforbtv/baby-equipment-exchange/issues/256) Excludes UI updates to mark disabled accounts.

Proposal for adding buttons on the edit user screen (admins) to disable/re-enable accounts.

Open questions:

- Should users always be emailed when their accounts are disabled/enabled?
- When an account is disabled, should admins still be able to update account details?
- Should disabled accounts be grouped separately?