### PR TITLE
staging-dev:bugfix: donation approval fail, null category error

### DIFF
--- a/src/components/AdminDonationForm.tsx
+++ b/src/components/AdminDonationForm.tsx
@@ -56,7 +56,7 @@ export default function AdminDonationForm(props: DonationFormProps) {
     };
 
     const isDisabled =
-        !images || formData.category?.length === 0 || formData.brand?.length === 0 || formData.model?.length === 0 || formData.description?.length === 0;
+        !images || !formData.category || formData.brand?.length === 0 || formData.model?.length === 0 || formData.description?.length === 0;
 
     useEffect(() => {
         const tempImages = [];
@@ -153,7 +153,7 @@ export default function AdminDonationForm(props: DonationFormProps) {
                                     sx={{ maxWidth: '87%' }}
                                     disablePortal
                                     options={categories.map((option) => option.name)}
-                                    renderInput={(params) => <TextField {...params} label="Category" />}
+                                    renderInput={(params) => <TextField {...params} label="Category" required />}
                                     value={formData.category}
                                     onChange={handleCategoryChange}
                                     aria-label="Category"
@@ -164,6 +164,7 @@ export default function AdminDonationForm(props: DonationFormProps) {
                                     name="brand"
                                     id="brand"
                                     placeholder=" Brand"
+                                    required
                                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(e)}
                                     value={formData.brand ? formData.brand : ''}
                                 ></TextField>
@@ -172,6 +173,7 @@ export default function AdminDonationForm(props: DonationFormProps) {
                                     label="Model"
                                     name="model"
                                     id="model"
+                                    required
                                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(e)}
                                     value={formData.model ? formData.model : ''}
                                 ></TextField>
@@ -179,6 +181,7 @@ export default function AdminDonationForm(props: DonationFormProps) {
                                     multiline={true}
                                     name="description"
                                     label="Description"
+                                    required
                                     rows={12}
                                     placeholder="Key details might include: special features, accessories, how the item works, ease of cleaning, size, and/or information about missing or damaged parts"
                                     id="description"

--- a/src/components/DonationForm.tsx
+++ b/src/components/DonationForm.tsx
@@ -57,7 +57,7 @@ export default function DonationForm(props: DonationFormProps) {
     };
 
     const isDisabled =
-        !images || formData.category?.length === 0 || formData.brand?.length === 0 || formData.model?.length === 0 || formData.description?.length === 0;
+        !images || !formData.category || formData.brand?.length === 0 || formData.model?.length === 0 || formData.description?.length === 0;
 
     const isCategoryActive = (category: string) => {
         if (categories) {
@@ -167,7 +167,7 @@ export default function DonationForm(props: DonationFormProps) {
                                     disablePortal
                                     options={categories.map((option) => option.name)}
                                     getOptionDisabled={isCategoryActive}
-                                    renderInput={(params) => <TextField {...params} label="Category" />}
+                                    renderInput={(params) => <TextField {...params} label="Category" required />}
                                     value={formData.category}
                                     onChange={handleCategoryChange}
                                     aria-label="Category"
@@ -178,6 +178,7 @@ export default function DonationForm(props: DonationFormProps) {
                                     name="brand"
                                     id="brand"
                                     placeholder=" Brand"
+                                    required
                                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(e)}
                                     value={formData.brand ? formData.brand : ''}
                                 ></TextField>
@@ -186,6 +187,7 @@ export default function DonationForm(props: DonationFormProps) {
                                     label="Model"
                                     name="model"
                                     id="model"
+                                    required
                                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(e)}
                                     value={formData.model ? formData.model : ''}
                                 ></TextField>
@@ -193,6 +195,7 @@ export default function DonationForm(props: DonationFormProps) {
                                     multiline={true}
                                     name="description"
                                     label="Description"
+                                    required
                                     rows={12}
                                     placeholder="Key details might include: special features, accessories, how the item works, ease of cleaning, size, and/or information about missing or damaged parts"
                                     id="description"


### PR DESCRIPTION
Fixes [#321](https://github.com/codeforbtv/baby-equipment-exchange/issues/321)

`formData.category` starts as `null`. The disabled check was `formData.category?.length === 0`. `null?.length` is `undefined`, and `undefined === 0` is `false`, so the "Add item" button was enabled with no category selected. Empty category then crashes `getTagNumber` downstream when admin tries to approve.

## Changes

* Fix `isDisabled` check in `DonationForm.tsx` and `AdminDonationForm.tsx`. `formData.category?.length === 0` → `!formData.category`
* Added `required` to all form fields so users can see what needs to be filled out
