### PR TITLE
staging-dev:bugfix silent failures and stuck state in donation approval and order management

### DIFF
--- a/src/api/firebase-categories.ts
+++ b/src/api/firebase-categories.ts
@@ -134,7 +134,10 @@ export async function getTagNumber(category: string): Promise<string> {
         const docRef = docSnap.ref;
         docRefs.push(docRef);
     });
-    //Use first (and only) query to obtain doc ref for transaction
+    if (docRefs.length === 0) {
+        throw new Error(`Category not found: "${category}". No matching category exists.`);
+    }
+
     const categoryRef = docRefs[0];
     let tagNumber = '';
     try {

--- a/src/api/firebase-donations.ts
+++ b/src/api/firebase-donations.ts
@@ -537,12 +537,20 @@ export async function getOrdersNotifications() {
             };
             for (const donation of orderInfo.items) {
                 const donationDetails = await getDoc(donation);
-                order.items.push(donationDetails.data() as Donation);
+                if (donationDetails.exists()) {
+                    order.items.push(donationDetails.data() as Donation);
+                } else {
+                    console.warn(`Order ${doc.id}: referenced donation ${donation.id} not found, skipping`);
+                }
             }
             if (orderInfo.rejectedItems) {
                 for (const donation of orderInfo.rejectedItems) {
                     const donationDetails = await getDoc(donation);
-                    order.rejectedItems?.push(donationDetails.data() as Donation);
+                    if (donationDetails.exists()) {
+                        order.rejectedItems?.push(donationDetails.data() as Donation);
+                    } else {
+                        console.warn(`Order ${doc.id}: referenced rejected donation ${donation.id} not found, skipping`);
+                    }
                 }
             }
 
@@ -570,12 +578,20 @@ export async function getOrderById(id: string): Promise<Order> {
             };
             for (const donation of orderInfo.items) {
                 const donationDetails = await getDoc(donation);
-                order.items.push(donationDetails.data() as Donation);
+                if (donationDetails.exists()) {
+                    order.items.push(donationDetails.data() as Donation);
+                } else {
+                    console.warn(`Order ${id}: referenced donation ${donation.id} not found, skipping`);
+                }
             }
             if (orderInfo.rejectedItems) {
                 for (const donation of orderInfo.rejectedItems) {
                     const donationDetails = await getDoc(donation);
-                    order.rejectedItems?.push(donationDetails.data() as Donation);
+                    if (donationDetails.exists()) {
+                        order.rejectedItems?.push(donationDetails.data() as Donation);
+                    } else {
+                        console.warn(`Order ${id}: referenced rejected donation ${donation.id} not found, skipping`);
+                    }
                 }
             }
             return order;
@@ -614,6 +630,12 @@ export async function removeDonationFromOrder(orderId: string, donation: Donatio
             modifiedAt: serverTimestamp()
         });
         await batch.commit();
+
+        const updatedOrder = await getDoc(orderRef);
+        const orderData = updatedOrder.data();
+        if (orderData && orderData.items.length === 0 && orderData.rejectedItems?.length > 0) {
+            await closeOrder(orderId);
+        }
     } catch (error) {
         addErrorEvent('Error removing donation from order', error);
     }

--- a/src/components/DonationCardMed.tsx
+++ b/src/components/DonationCardMed.tsx
@@ -25,10 +25,10 @@ import '@/styles/globalStyles.css';
 import { Donation } from '@/models/donation';
 
 type DonationCardMedProps = {
-    orderId: string;
+    orderId?: string;
     donation: Donation;
     setIdToDisplay: Dispatch<SetStateAction<string | null>>;
-    handleRemoveFromOrder: (orderId: string, donation: Donation) => Promise<void>;
+    handleRemoveFromOrder?: (orderId: string, donation: Donation) => Promise<void>;
 };
 
 const DonationCardMed = (props: DonationCardMedProps) => {
@@ -37,7 +37,9 @@ const DonationCardMed = (props: DonationCardMedProps) => {
     const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
 
     const handleRemove = async (id: string, donation: Donation) => {
-        await handleRemoveFromOrder(id, donation);
+        if (handleRemoveFromOrder) {
+            await handleRemoveFromOrder(id, donation);
+        }
     };
 
     return (
@@ -53,7 +55,7 @@ const DonationCardMed = (props: DonationCardMedProps) => {
                     <Typography variant="h6">{donation.tagNumber}</Typography>
                 </CardContent>
 
-                {donation.status !== 'unavailable' && (
+                {handleRemoveFromOrder && orderId && (
                     <CardActions>
                         <Button variant="contained" startIcon={<RemoveShoppingCartIcon />} color="error" onClick={() => setShowRemoveDialog(true)}>
                             Remove
@@ -61,23 +63,24 @@ const DonationCardMed = (props: DonationCardMedProps) => {
                     </CardActions>
                 )}
             </Card>
-            {/* confirm remove dialog */}
-            <Dialog open={showRemoveDialog} aria-labelledby="dialog-title" aria-describedby="dialog-description">
-                <DialogTitle id="dialog-title">Remove Donation?</DialogTitle>
-                <DialogContent>
-                    <DialogContentText>
-                        This will remove {donation.model + ' ' + donation.brand} from this order and change its status to unavailable. Are you sure?
-                    </DialogContentText>
-                    <DialogActions>
-                        <Button variant="contained" onClick={() => handleRemove(orderId, donation)}>
-                            Confirm
-                        </Button>
-                        <Button variant="outlined" onClick={() => setShowRemoveDialog(false)}>
-                            Cancel
-                        </Button>
-                    </DialogActions>
-                </DialogContent>
-            </Dialog>
+            {handleRemoveFromOrder && orderId && (
+                <Dialog open={showRemoveDialog} aria-labelledby="dialog-title" aria-describedby="dialog-description">
+                    <DialogTitle id="dialog-title">Remove Donation?</DialogTitle>
+                    <DialogContent>
+                        <DialogContentText>
+                            This will remove {donation.model + ' ' + donation.brand} from this order and change its status to unavailable. Are you sure?
+                        </DialogContentText>
+                        <DialogActions>
+                            <Button variant="contained" onClick={() => handleRemove(orderId, donation)}>
+                                Confirm
+                            </Button>
+                            <Button variant="outlined" onClick={() => setShowRemoveDialog(false)}>
+                                Cancel
+                            </Button>
+                        </DialogActions>
+                    </DialogContent>
+                </Dialog>
+            )}
         </ProtectedAdminRoute>
     );
 };

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -64,7 +64,7 @@ const Notifications = (props: NotificationsProps) => {
     const sortedDonationsAwaitingDropoff = sortArrayByBulkId(donationsAwaitingDropoff);
     const donationsAwaitingPickup = notifications.donations.filter((donation) => donation.status === 'reserved');
     const sortedDonationsAwaitingPickup = sortArrayByBulkId(donationsAwaitingPickup);
-    const orders = notifications.orders;
+    const orders = notifications.orders.filter((order) => order.items.length > 0);
     const usersAwaitingApproval = notifications.users.filter((user) => !user.isDeleted); //Filters out recently deleted users
 
     const router = useRouter();

--- a/src/components/ReviewOrder.tsx
+++ b/src/components/ReviewOrder.tsx
@@ -129,10 +129,8 @@ const ReviewOrder = (props: ReviewOrderProps) => {
                                     {currentOrder.rejectedItems.map((item) => (
                                         <DonationCardMed
                                             key={item.id}
-                                            orderId={item.id}
                                             donation={item}
                                             setIdToDisplay={setDonationIdToDisplay}
-                                            handleRemoveFromOrder={handleRemoveFromOrder}
                                         />
                                     ))}
                                 </>

--- a/src/components/ScheduleDropOff.tsx
+++ b/src/components/ScheduleDropOff.tsx
@@ -39,6 +39,7 @@ const ScheduleDropOff = (props: ScheduleDropOffProps) => {
     const [inviteUrl, setInviteUrl] = useState<string>('');
     const [notes, setNotes] = useState<string>('');
     const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
+    const [errorMessage, setErrorMessage] = useState<string>('');
 
     const router = useRouter();
 
@@ -147,7 +148,11 @@ const ScheduleDropOff = (props: ScheduleDropOffProps) => {
         } catch (error) {
             addErrorEvent('Error submitting accept/reject email', error);
             posthog.captureException(error);
-            throw error;
+            if (error instanceof Error && error.message.startsWith('Category not found:')) {
+                setErrorMessage(error.message);
+            } else {
+                setErrorMessage('An unexpected error occurred while processing donations. Please try again.');
+            }
         } finally {
             setIsLoading(false);
         }
@@ -217,6 +222,12 @@ const ScheduleDropOff = (props: ScheduleDropOffProps) => {
                 </>
             )}
             <CustomDialog isOpen={isDialogOpen} onClose={handleClose} title="Email sent" content={`Email successfully sent to ${donorEmail}`} />
+            <CustomDialog
+                isOpen={errorMessage !== ''}
+                onClose={() => setErrorMessage('')}
+                title="Error Processing Donations"
+                content={errorMessage}
+            />
         </ProtectedAdminRoute>
     );
 };


### PR DESCRIPTION
[Short Explanation](https://drive.google.com/file/d/1v9OlNOzQNcVxMm0T7DK7iDcDW7AOWJa-/view?usp=drive_link). I recommend watching in 1.25-1.5x speed.


## What was broken

1. **Deleted donation refs crash notifications (#324).** If a Donation doc gets deleted from Firestore, any order referencing it crashes — `getDoc` returns undefined, we push it into the array without checking.

2. **Rejected orders stuck in queue.** `removeDonationFromOrder` moves items to `rejectedItems` but never checks if `items` is empty after. Orders with all items rejected stay `status: 'open'` forever.

3. **Wrong `orderId` on rejected items (#323).** `ReviewOrder` passes `item.id` (donation ID) instead of the order ID. Remove action writes to wrong Firestore path.

4. **Stale remove button on rejected items (#322).** After rejecting, local state keeps `status: 'requested'` — Remove button shows on rejected items until Firestore re-fetch.

5. **`getTagNumber` crashes silently (#310).** Donation with category not in `Categories` collection → `docRefs[0]` on empty array → crash. Admin sees spinner stop, nothing else. Upstream form validation fix in #328, this handles existing bad data + shows error dialog.

## Changes

- `getOrdersNotifications` and `getOrderById` check `donationDetails.exists()` before pushing. Missing refs skipped with `console.warn`.
- `removeDonationFromOrder` re-reads order after commit, calls `closeOrder` if `items` empty. `Notifications` filters out empty orders for pre-existing stuck ones.
- `handleRemoveFromOrder` and `orderId` optional on `DonationCardMed`. Not passed for rejected items — no button renders. Kills bugs 3 and 4.
- `getTagNumber` throws typed error on empty query. `ScheduleDropOff` catches it, shows dialog with category name. Generic fallback for other errors.

No data migration. Code now tolerates existing bad state and prevents new.

Closes #310, #322, #323, #324