### PR TITLE
staging-dev:bugfix typos, memory leak, logic errors

### DIFF
--- a/src/api/firebase-donations.ts
+++ b/src/api/firebase-donations.ts
@@ -389,19 +389,19 @@ export async function updateDonationStatus(id: string, status: DonationStatusVal
         if (status === 'available') {
             statusUpdate = {
                 status: status,
-                modfiedAt: serverTimestamp(),
+                modifiedAt: serverTimestamp(),
                 dateReceived: serverTimestamp()
             };
         } else if (status === 'distributed') {
             statusUpdate = {
                 status: status,
-                modfiedAt: serverTimestamp(),
+                modifiedAt: serverTimestamp(),
                 dateDistributed: serverTimestamp()
             };
         } else {
             statusUpdate = {
                 status: status,
-                modfiedAt: serverTimestamp()
+                modifiedAt: serverTimestamp()
             };
         }
         await updateDoc(donationRef, statusUpdate);
@@ -444,8 +444,8 @@ export async function adminAreDonationsAvailable(ids: string[]): Promise<string[
             if (donation && donation.status !== 'available') {
                 unavailableDonations.push(donation.id);
             }
-            return unavailableDonations;
         }
+        return unavailableDonations;
     } catch (error) {
         addErrorEvent('Admin are donations available', error);
     }

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -249,7 +249,7 @@ export default function Donate() {
                                     helperText={emailsDoNotMatch ? 'Emails do not match.' : undefined}
                                     required
                                     onChange={handleConfirmEmail}
-                                    onBlur={() => handleConfirmEmail}
+                                    onBlur={(e:any) => handleConfirmEmail(e )}
                                 />
                                 <Button type="button" variant="contained" onClick={handleSave} disabled={isDisabled} sx={{ marginTop: '1em' }}>
                                     Save

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -203,7 +203,7 @@ export default function NewAccount() {
                                 autoComplete="email"
                                 value={email}
                                 error={isEmailInUse || isInvalidEmail}
-                                helperText={(isInvalidEmail && 'Please enter a valid email addres') || (isEmailInUse && 'This email is already in use')}
+                                helperText={(isInvalidEmail && 'Please enter a valid email address') || (isEmailInUse && 'This email is already in use')}
                                 required
                                 onChange={handleEmailInput}
                                 onBlur={handleBlur}

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -65,7 +65,7 @@ export default function ResetPassword() {
                 <>
                     <div className="page--header">
                         <h1>Reset Password</h1>
-                        <h4>Enter an email and instructions for restting your password will be sent to you.</h4>
+                        <h4>Enter an email and instructions for resetting your password will be sent to you.</h4>
                     </div>
                     <div className="content--container">
                         <Box component="form" gap={3} display={'flex'} flexDirection={'column'} onSubmit={handlePasswordReset}>
@@ -78,7 +78,7 @@ export default function ResetPassword() {
                                 autoComplete="email"
                                 value={email}
                                 error={isInvalidEmail}
-                                helperText={isInvalidEmail ? 'Please enter a valid email addres' : undefined}
+                                helperText={isInvalidEmail ? 'Please enter a valid email address' : undefined}
                                 required
                                 onChange={handleEmailInput}
                                 onBlur={handleBlur}

--- a/src/components/EditUser.tsx
+++ b/src/components/EditUser.tsx
@@ -203,7 +203,7 @@ const EditUser = (props: EditUserProps) => {
                             autoComplete="email"
                             value={newEmail}
                             error={isEmailInUse || isInvalidEmail}
-                            helperText={(isInvalidEmail && 'Please enter a valid email addres') || (isEmailInUse && 'This email is already in use')}
+                            helperText={(isInvalidEmail && 'Please enter a valid email address') || (isEmailInUse && 'This email is already in use')}
                             required
                             onChange={handleEmailInput}
                             onBlur={handleBlur}

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -61,7 +61,7 @@ export const UserProvider = ({ children }: Props) => {
                 setIsLoading(false);
             }
         });
-        return () => unsubscribe;
+        return unsubscribe;
     }, []);
 
     return <UserContext.Provider value={value}>{children}</UserContext.Provider>;

--- a/src/email-templates/schedulePickup.ts
+++ b/src/email-templates/schedulePickup.ts
@@ -22,7 +22,7 @@ export default function schedulePickup(email: string, inviteUrl: string, message
         to: email,
         cc: emailCc,
         from: emailSender,
-        subject: 'Your Baby Product Exchange order has been fufilled',
+        subject: 'Your Baby Product Exchange order has been fulfilled',
         html: html
     };
 }

--- a/src/types/OrdersTypes.ts
+++ b/src/types/OrdersTypes.ts
@@ -8,5 +8,5 @@ export type Order = {
     items: Donation[];
     rejectedItems?: Donation[];
     createdAt?: Timestamp;
-    modfiedAt?: Timestamp;
+    modifiedAt?: Timestamp;
 };


### PR DESCRIPTION
Found these while doing a codebase audit. All one-liners, all independent. Only one of these tracked as an issue.

### Bugs
**Auth listener memory leak** In `UserContext.tsx`, the useEffect cleanup had `return () => unsubscribe` which creates an arrow function that returns the unsubscribe function without ever calling it. So the Firebase auth listener was never getting cleaned up, every time `UserProvider` mounted it'd leak another listener. Changed it to `return unsubscribe`.

**Admin cart only checks first item ([#325](https://github.com/codeforbtv/baby-equipment-exchange/issues/325))** In `adminAreDonationsAvailable`, the `return unavailableDonations` was inside the for loop, so the function always bailed after checking just the first donation. If you had 2+ items in an admin cart and item 2 or 3 was unavailable, it'd slip right through. Moved the return outside the loop.

**Confirm email blur validation never ran** On `/donate`, the confirm email field had `onBlur={() => handleConfirmEmail}` which just returns the function reference without calling it. If you typed a mismatched email and tabbed out, nothing happened, validation only fired on keystrokes via onChange. Fixed the handler so it actually gets called on blur.

**`modfiedAt` typo** `updateDonationStatus` was writing to a misspelled `modfiedAt` field (missing the 'i') in all three status branches, and the `Order` type had the same typo. The correctly spelled `modifiedAt` field never got updated on status changes, so any sort or query on it would return stale data. Fixed all 4 occurrences.

**"fufilled" in email subject** The schedule pickup email had "Your Baby Product Exchange order has been fufilled" as the subject line. Fixed the spelling.

**"restting" and "addres" in forms** The reset password page said "instructions for restting your password" and three different forms showed "Please enter a valid email addres" on validation errors. Fixed all 4 occurrences across `/reset-password`, `/join`, and the admin edit user page.

Closes #325