### PR TITLE
staging-dev:bugfix: notification page flash state loss

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -81,8 +81,8 @@ export default function Dashboard() {
         setCurrentTab(target);
     };
 
-    async function fetchNotifications(): Promise<void> {
-        setIsLoading(true);
+    async function fetchNotifications(showLoader = false): Promise<void> {
+        if (showLoader || !notifications) setIsLoading(true);
         try {
             const notificationsResult = await getNotifications();
             setNotifications(notificationsResult);
@@ -94,8 +94,8 @@ export default function Dashboard() {
         }
     }
 
-    async function fetchDonations(): Promise<void> {
-        setIsLoading(true);
+    async function fetchDonations(showLoader = false): Promise<void> {
+        if (showLoader || !donations) setIsLoading(true);
         try {
             const donationsResult = await getAllDonations();
             setDonations(donationsResult);
@@ -107,8 +107,8 @@ export default function Dashboard() {
         }
     }
 
-    async function fetchInventory(): Promise<void> {
-        setIsLoading(true);
+    async function fetchInventory(showLoader = false): Promise<void> {
+        if (showLoader || !inventory) setIsLoading(true);
         try {
             const inventoryResult = await getAllInventory();
             setInventory(inventoryResult);
@@ -119,8 +119,8 @@ export default function Dashboard() {
         }
     }
 
-    async function fetchUsers(): Promise<void> {
-        setIsLoading(true);
+    async function fetchUsers(showLoader = false): Promise<void> {
+        if (showLoader || !users) setIsLoading(true);
         try {
             const usersResult = await getAllDbUsers();
             setUsers(usersResult.filter((user) => !user.isDeleted));
@@ -132,8 +132,8 @@ export default function Dashboard() {
         }
     }
 
-    async function fetchOrgNames(): Promise<void> {
-        setIsLoading(true);
+    async function fetchOrgNames(showLoader = false): Promise<void> {
+        if (showLoader || !orgNamesAndIds) setIsLoading(true);
         try {
             const orgNamesResult = await callGetOrganizationNames();
             setOrgNamesAndIds(orgNamesResult);
@@ -145,8 +145,8 @@ export default function Dashboard() {
         }
     }
 
-    async function fetchCategories(): Promise<void> {
-        setIsLoading(true);
+    async function fetchCategories(showLoader = false): Promise<void> {
+        if (showLoader || !categories) setIsLoading(true);
         try {
             const categoriesResult = await getAllCategories();
             setCategories(categoriesResult);
@@ -160,17 +160,17 @@ export default function Dashboard() {
 
     function handleRefresh() {
         if (currentTab === 0) {
-            fetchNotifications();
+            fetchNotifications(true);
         } else if (currentTab === 1) {
-            fetchDonations();
+            fetchDonations(true);
         } else if (currentTab === 2) {
-            fetchInventory();
+            fetchInventory(true);
         } else if (currentTab === 3) {
-            fetchUsers();
+            fetchUsers(true);
         } else if (currentTab === 4) {
-            fetchOrgNames();
+            fetchOrgNames(true);
         } else if (currentTab === 5) {
-            fetchCategories();
+            fetchCategories(true);
         }
     }
 

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -75,12 +75,10 @@ const NotificationCard = (props: NotificationCardProps) => {
         try {
             await updateDonationStatus(id, 'available');
             if (setNotificationsUpdated) setNotificationsUpdated(true);
-            window.location.reload();
         } catch (error) {
+            setIsLoading(false);
             addErrorEvent('Mark donation as received', error);
             throw error;
-        } finally {
-            setIsLoading(false);
         }
     };
 
@@ -102,12 +100,10 @@ const NotificationCard = (props: NotificationCardProps) => {
         try {
             await markDonationAsDistributed(donation);
             if (setNotificationsUpdated) setNotificationsUpdated(true);
-            window.location.reload();
         } catch (error) {
+            setIsLoading(false);
             addErrorEvent('Mark as distributed', error);
             throw error;
-        } finally {
-            setIsLoading(false);
         }
     };
 
@@ -118,12 +114,10 @@ const NotificationCard = (props: NotificationCardProps) => {
                 status: 'available'
             });
             if (setNotificationsUpdated) setNotificationsUpdated(true);
-            window.location.reload();
         } catch (error) {
+            setIsLoading(false);
             addErrorEvent('Return to inventory', error);
             throw error;
-        } finally {
-            setIsLoading(false);
         }
     };
 

--- a/src/components/SchedulePickup.tsx
+++ b/src/components/SchedulePickup.tsx
@@ -44,7 +44,6 @@ const SchedulePickup = (props: SchedulePickupProps) => {
     const handleClose = () => {
         setIsDialogOpen(false);
         router.push('/');
-        window.location.reload();
     };
 
     const handleSelect = (event: ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
Every action on the notifications dashboard (Add to Inventory, Mark Distributed, Return to Inventory, etc.) triggers a full page reload. This destroys scroll position, resets the tab, and flashes "No notifications" / "Loading..." before the data comes back. 

The root cause is two things stacked on top of each other:

1. `window.location.reload()` called after every action in `NotificationCard.tsx` and `SchedulePickup.tsx`, even though `setNotificationsUpdated(true)` already triggers a re-fetch through Dashboard's `useEffect`
2. Dashboard's `fetchNotifications()` (and all 5 other fetch functions) unconditionally call `setIsLoading(true)`, which swaps the entire tab panel tree for a single `<Loader />`. This unmounts everything — same effect as a reload, just driven by React state instead of the browser

The reload was masking # 2. Once I removed the reloads, the `isLoading` flash became visible.

## Changes

* Removed 4 `window.location.reload()` calls, 3 in `NotificationCard.tsx` (markAsReceived, markAsDistributed, returnToInventory) and 1 in `SchedulePickup.tsx` (handleClose)
* Gated `setIsLoading(true)` in all 6 Dashboard fetch functions behind `showLoader || !<collection>` first load still shows the loader, background re-fetches are silent
* `handleRefresh()` passes `showLoader=true` so the manual refresh button still gives visual feedback
* Changed `finally { setIsLoading(false) }` to `catch`-only reset in the 3 card action functions that remove items from the list, preventing the card from briefly "flashing back" between the action completing and the re-fetch arriving

### What it looks like now

1. Click "Add to Inventory" → card shows its own spinner → card disappears when re-fetch data arrives
2. Tab bar, other cards, scroll position all stay in place
3. No full-page loader, no "No notifications" flash

| File | What changed |
| :--- | :--- |
| `NotificationCard.tsx` | Removed 3 `window.location.reload()`, moved `setIsLoading(false)` to catch-only for actions that remove cards |
| `SchedulePickup.tsx` | Removed 1 `window.location.reload()` (redundant after `router.push('/')`) |
| `Dashboard.tsx` | Added `showLoader` param to all 6 fetch functions, gated loader on first-load or explicit refresh |

Fixes #330 

### Testing

Seed emulators, login as `admin1@email.com`. On the Notifications tab:
- **Add to Inventory** on a pending delivery → card spinner, card disappears, no page reload
- **Mark as distributed** / **Return to Inventory** on a reserved donation → same behavior
- **Approve** a pending user → dialog, dismiss, list refreshes in place
- **Refresh button** → full-page loader (intentional, `showLoader=true`)
- Scroll position preserved through all actions
