### PR TITLE
staging-dev:enhan: notification page admin qol redesign

### DIFF
--- a/scripts/seed-emulators.cjs
+++ b/scripts/seed-emulators.cjs
@@ -173,6 +173,27 @@ const DONOR1_DONATIONS = [
     }
 ];
 
+const DONOR1_DONATIONS_BATCH2 = [
+    {
+        id: 'donation-mj-004',
+        category: 'High Chairs',
+        brand: 'IKEA',
+        model: 'ANTILOP',
+        description: 'White high chair with tray and inflatable cushion. Legs detach for transport.',
+        status: 'in processing',
+        images: ['https://placehold.co/400x300/e8e8e8/666?text=High+Chair']
+    },
+    {
+        id: 'donation-mj-005',
+        category: 'Clothing',
+        brand: 'Mixed',
+        model: '12-18 months bundle',
+        description: '15-piece lot: pants, long-sleeve tops, fleece jacket. Gender neutral colors.',
+        status: 'in processing',
+        images: ['https://placehold.co/400x300/e8e8e8/666?text=Clothing']
+    }
+];
+
 const DONOR2_DONATIONS = [
     {
         id: 'donation-sam-001',
@@ -284,7 +305,7 @@ const ADMIN_DONATIONS = [
     }
 ];
 
-const PENDING_DELIVERY_DONATIONS = [
+const DONOR1_PENDING_DELIVERY = [
     {
         id: 'donation-pd-001',
         category: 'Cribs',
@@ -292,9 +313,6 @@ const PENDING_DELIVERY_DONATIONS = [
         model: 'Pack \'n Play',
         description: 'Portable playard with bassinet attachment. Includes carry bag.',
         status: 'pending delivery',
-        donorEmail: 'dana@email.com',
-        donorName: 'Dana Torres',
-        donorId: 'donor1',
         images: ['https://placehold.co/400x300/e8e8e8/666?text=Pack-n-Play']
     },
     {
@@ -304,14 +322,41 @@ const PENDING_DELIVERY_DONATIONS = [
         model: 'Free-to-Grow',
         description: 'Mesh carrier, newborn to toddler. Coast line pattern.',
         status: 'pending delivery',
-        donorEmail: 'dana@email.com',
-        donorName: 'Dana Torres',
-        donorId: 'donor1',
         images: ['https://placehold.co/400x300/e8e8e8/666?text=Baby+Carrier']
     }
 ];
 
-const RESERVED_DONATIONS = [
+const DONOR2_PENDING_DELIVERY = [
+    {
+        id: 'donation-pd-003',
+        category: 'Toys',
+        brand: 'Melissa & Doug',
+        model: 'Wooden Activity Cube',
+        description: 'Five-sided play cube with bead maze, shape sorter, spinning gears.',
+        status: 'pending delivery',
+        images: ['https://placehold.co/400x300/e8e8e8/666?text=Activity+Cube']
+    },
+    {
+        id: 'donation-pd-004',
+        category: 'Changing Tables',
+        brand: 'Keekaroo',
+        model: 'Peanut Changer',
+        description: 'Contoured changing pad, vanilla color. Wipeable surface, no cover needed.',
+        status: 'pending delivery',
+        images: ['https://placehold.co/400x300/e8e8e8/666?text=Changing+Pad']
+    },
+    {
+        id: 'donation-pd-005',
+        category: 'Monitors',
+        brand: 'Nanit',
+        model: 'Pro Camera',
+        description: 'Wall-mount smart camera with breathing band. Factory reset complete.',
+        status: 'pending delivery',
+        images: ['https://placehold.co/400x300/e8e8e8/666?text=Monitor']
+    }
+];
+
+const RESERVED_DONATIONS_ANON = [
     {
         id: 'donation-res-001',
         category: 'Strollers',
@@ -337,6 +382,19 @@ const RESERVED_DONATIONS = [
         donorName: 'Anonymous Drop-Off',
         donorId: 'admin1',
         images: ['https://placehold.co/400x300/e8e8e8/666?text=Clothing']
+    }
+];
+
+const RESERVED_DONATIONS_DONOR2 = [
+    {
+        id: 'donation-res-003',
+        category: 'Cribs',
+        brand: 'Babyletto',
+        model: 'Lolly 3-in-1',
+        description: 'White and natural finish. Toddler bed conversion kit included.',
+        status: 'reserved',
+        tagNumber: 'CRB 4',
+        images: ['https://placehold.co/400x300/e8e8e8/666?text=Crib']
     }
 ];
 
@@ -495,6 +553,9 @@ async function seed() {
     console.log(`  Bulk from ${USERS.donor1.displayName}: ${DONOR1_DONATIONS.length} items (in processing)`);
     console.log('    ** donation-mj-003 has category "Play Mats" — Bug 1 repro **');
 
+    await createBulkDonation('bulk-donor1-002', USERS.donor1, DONOR1_DONATIONS_BATCH2);
+    console.log(`  Bulk #2 from ${USERS.donor1.displayName}: ${DONOR1_DONATIONS_BATCH2.length} items (in processing) — same donor, separate submission`);
+
     await createBulkDonation('bulk-donor2-001', USERS.donor2, DONOR2_DONATIONS);
     console.log(`  Bulk from ${USERS.donor2.displayName}: ${DONOR2_DONATIONS.length} items (in processing)`);
 
@@ -511,10 +572,13 @@ async function seed() {
         console.log(`  ${d.tagNumber}: ${d.brand} ${d.model} [${d.status}]`);
     }
 
-    await createBulkDonation('bulk-pd-001', USERS.donor1, PENDING_DELIVERY_DONATIONS);
-    console.log(`  Bulk pending delivery from Dana Torres: ${PENDING_DELIVERY_DONATIONS.length} items`);
+    await createBulkDonation('bulk-pd-donor1-001', USERS.donor1, DONOR1_PENDING_DELIVERY);
+    console.log(`  Bulk pending delivery from ${USERS.donor1.displayName}: ${DONOR1_PENDING_DELIVERY.length} items`);
 
-    for (const d of RESERVED_DONATIONS) {
+    await createBulkDonation('bulk-pd-donor2-001', USERS.donor2, DONOR2_PENDING_DELIVERY);
+    console.log(`  Bulk pending delivery from ${USERS.donor2.displayName}: ${DONOR2_PENDING_DELIVERY.length} items`);
+
+    for (const d of RESERVED_DONATIONS_ANON) {
         d.requestor = {
             id: USERS.aidWorker.uid,
             name: USERS.aidWorker.displayName,
@@ -523,6 +587,17 @@ async function seed() {
         const donDoc = makeDonationDoc(d, USERS.admin);
         await db.collection('Donations').doc(d.id).set(donDoc);
         console.log(`  ${d.tagNumber}: ${d.brand} ${d.model} [${d.status}] — reserved for ${USERS.aidWorker.displayName}`);
+    }
+
+    for (const d of RESERVED_DONATIONS_DONOR2) {
+        d.requestor = {
+            id: USERS.aidWorker2.uid,
+            name: USERS.aidWorker2.displayName,
+            email: USERS.aidWorker2.email
+        };
+        const donDoc = makeDonationDoc(d, USERS.donor2);
+        await db.collection('Donations').doc(d.id).set(donDoc);
+        console.log(`  ${d.tagNumber}: ${d.brand} ${d.model} [${d.status}] — reserved for ${USERS.aidWorker2.displayName}`);
     }
 
     for (const d of HISTORY_DONATIONS) {
@@ -577,6 +652,58 @@ async function seed() {
 
     await db
         .collection('Orders')
+        .doc('order-normal-002')
+        .set({
+            status: 'open',
+            requestor: {
+                id: USERS.aidWorker.uid,
+                name: USERS.aidWorker.displayName,
+                email: USERS.aidWorker.email
+            },
+            items: [db.collection('Donations').doc('donation-admin-004')],
+            createdAt: FieldValue.serverTimestamp(),
+            modifiedAt: FieldValue.serverTimestamp()
+        });
+    await db.collection('Donations').doc('donation-admin-004').update({
+        status: 'requested',
+        requestor: {
+            id: USERS.aidWorker.uid,
+            name: USERS.aidWorker.displayName,
+            email: USERS.aidWorker.email
+        },
+        dateRequested: FieldValue.serverTimestamp(),
+        modifiedAt: FieldValue.serverTimestamp()
+    });
+    console.log('  order-normal-002: Ergobaby Omni 360 [open, 1 item] — second order from Noor');
+
+    await db
+        .collection('Orders')
+        .doc('order-normal-003')
+        .set({
+            status: 'open',
+            requestor: {
+                id: USERS.aidWorker2.uid,
+                name: USERS.aidWorker2.displayName,
+                email: USERS.aidWorker2.email
+            },
+            items: [db.collection('Donations').doc('donation-admin-005')],
+            createdAt: FieldValue.serverTimestamp(),
+            modifiedAt: FieldValue.serverTimestamp()
+        });
+    await db.collection('Donations').doc('donation-admin-005').update({
+        status: 'requested',
+        requestor: {
+            id: USERS.aidWorker2.uid,
+            name: USERS.aidWorker2.displayName,
+            email: USERS.aidWorker2.email
+        },
+        dateRequested: FieldValue.serverTimestamp(),
+        modifiedAt: FieldValue.serverTimestamp()
+    });
+    console.log('  order-normal-003: Mixed Clothing bundle [open, 1 item] — order from Jules');
+
+    await db
+        .collection('Orders')
         .doc('order-stuck-001')
         .set({
             status: 'open',
@@ -603,7 +730,8 @@ async function seed() {
         .update({
             requestedItems: [
                 { id: 'donation-admin-001', model: 'KeyFit 35' },
-                { id: 'donation-admin-003', model: 'S1 Plus' }
+                { id: 'donation-admin-003', model: 'S1 Plus' },
+                { id: 'donation-admin-004', model: 'Omni 360' }
             ],
             modifiedAt: FieldValue.serverTimestamp()
         });
@@ -611,6 +739,7 @@ async function seed() {
         .collection('Users')
         .doc(USERS.aidWorker2.uid)
         .update({
+            requestedItems: [{ id: 'donation-admin-005', model: '0-6 months bundle' }],
             distributedItems: [{ id: 'donation-hist-001', tagNumber: 'CRB 3' }],
             modifiedAt: FieldValue.serverTimestamp()
         });

--- a/scripts/seed-emulators.cjs
+++ b/scripts/seed-emulators.cjs
@@ -66,7 +66,16 @@ const USERS = {
         displayName: 'Ash Linden',
         phoneNumber: '+10000000006',
         claims: { donor: true, verified: false },
-        organization: null
+        organization: { id: 'org-vt-connector', name: 'Vermont Connector' }
+    },
+    pendingUser2: {
+        uid: 'pending2',
+        email: 'pending2@email.com',
+        password: 'password',
+        displayName: 'Drew Patel',
+        phoneNumber: '+10000000007',
+        claims: { 'aid-worker': true, verified: false },
+        organization: { id: 'org-cvoeo', name: 'CVOEO' }
     }
 };
 
@@ -275,6 +284,62 @@ const ADMIN_DONATIONS = [
     }
 ];
 
+const PENDING_DELIVERY_DONATIONS = [
+    {
+        id: 'donation-pd-001',
+        category: 'Cribs',
+        brand: 'Graco',
+        model: 'Pack \'n Play',
+        description: 'Portable playard with bassinet attachment. Includes carry bag.',
+        status: 'pending delivery',
+        donorEmail: 'dana@email.com',
+        donorName: 'Dana Torres',
+        donorId: 'donor1',
+        images: ['https://placehold.co/400x300/e8e8e8/666?text=Pack-n-Play']
+    },
+    {
+        id: 'donation-pd-002',
+        category: 'Baby Carriers',
+        brand: 'Tula',
+        model: 'Free-to-Grow',
+        description: 'Mesh carrier, newborn to toddler. Coast line pattern.',
+        status: 'pending delivery',
+        donorEmail: 'dana@email.com',
+        donorName: 'Dana Torres',
+        donorId: 'donor1',
+        images: ['https://placehold.co/400x300/e8e8e8/666?text=Baby+Carrier']
+    }
+];
+
+const RESERVED_DONATIONS = [
+    {
+        id: 'donation-res-001',
+        category: 'Strollers',
+        brand: 'Baby Jogger',
+        model: 'City Mini GT2',
+        description: 'All-terrain stroller, hand brake, one-hand fold.',
+        status: 'reserved',
+        tagNumber: 'STR 7',
+        donorEmail: 'anonymous@babyproductexchange.org',
+        donorName: 'Anonymous Drop-Off',
+        donorId: 'admin1',
+        images: ['https://placehold.co/400x300/e8e8e8/666?text=Stroller']
+    },
+    {
+        id: 'donation-res-002',
+        category: 'Clothing',
+        brand: 'Mixed',
+        model: '6-12 months bundle',
+        description: '20-piece lot: onesies, sleepers, bibs.',
+        status: 'reserved',
+        tagNumber: 'CLT 19',
+        donorEmail: 'anonymous@babyproductexchange.org',
+        donorName: 'Anonymous Drop-Off',
+        donorId: 'admin1',
+        images: ['https://placehold.co/400x300/e8e8e8/666?text=Clothing']
+    }
+];
+
 const HISTORY_DONATIONS = [
     {
         id: 'donation-hist-001',
@@ -317,7 +382,7 @@ async function createFirestoreUser(userData) {
         email: userData.email,
         displayName: userData.displayName,
         customClaims: userData.claims,
-        isDisabled: false,
+        isDisabled: !userData.claims.verified,
         phoneNumber: userData.phoneNumber,
         requestedItems: [],
         distributedItems: [],
@@ -444,6 +509,20 @@ async function seed() {
         const donDoc = makeDonationDoc(d, USERS.admin);
         await db.collection('Donations').doc(d.id).set(donDoc);
         console.log(`  ${d.tagNumber}: ${d.brand} ${d.model} [${d.status}]`);
+    }
+
+    await createBulkDonation('bulk-pd-001', USERS.donor1, PENDING_DELIVERY_DONATIONS);
+    console.log(`  Bulk pending delivery from Dana Torres: ${PENDING_DELIVERY_DONATIONS.length} items`);
+
+    for (const d of RESERVED_DONATIONS) {
+        d.requestor = {
+            id: USERS.aidWorker.uid,
+            name: USERS.aidWorker.displayName,
+            email: USERS.aidWorker.email
+        };
+        const donDoc = makeDonationDoc(d, USERS.admin);
+        await db.collection('Donations').doc(d.id).set(donDoc);
+        console.log(`  ${d.tagNumber}: ${d.brand} ${d.model} [${d.status}] — reserved for ${USERS.aidWorker.displayName}`);
     }
 
     for (const d of HISTORY_DONATIONS) {

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -194,15 +194,13 @@ export default function Dashboard() {
 
     return (
         <ProtectedAdminRoute>
-            <div className={styles['navbar']} data-unmask="true">
+            <div className={styles['navbar']} data-unmask="true" style={{ alignItems: 'center' }}>
                 {matches ? (
-                    <>
-                        <Tabs value={currentTab} onChange={handleCurrentTab} aria-label="dashboard" variant="scrollable" scrollButtons="auto">
-                            {tabOptions.map((tab) => (
-                                <Tab key={tab} label={tab} sx={{ color: 'black' }} />
-                            ))}
-                        </Tabs>
-                    </>
+                    <Tabs value={currentTab} onChange={handleCurrentTab} aria-label="dashboard" variant="scrollable" scrollButtons="auto" sx={{ flex: 1 }}>
+                        {tabOptions.map((tab) => (
+                            <Tab key={tab} label={tab} sx={{ color: 'black' }} />
+                        ))}
+                    </Tabs>
                 ) : (
                     <>
                         <Button endIcon={<ArrowDropDownIcon />} onClick={handleClickListItem}>
@@ -217,14 +215,14 @@ export default function Dashboard() {
                         </Menu>
                     </>
                 )}
+                <IconButton onClick={handleRefresh} size="small" sx={{ ml: 'auto' }}>
+                    <RefreshIcon fontSize="small" />
+                </IconButton>
             </div>
             {isLoading ? (
                 <Loader />
             ) : (
                 <>
-                    <IconButton onClick={handleRefresh} size="large" sx={{ marginRight: 'auto', backgroundColor: '#f1f1f1', marginTop: '1rem' }}>
-                        <RefreshIcon />
-                    </IconButton>
 
                     <CustomTabPanel value={currentTab} index={0}>
                         {notifications ? (

--- a/src/components/Inventory.tsx
+++ b/src/components/Inventory.tsx
@@ -157,7 +157,7 @@ const Inventory = (props: InventoryProps) => {
             )}
             {!idToDisplay && (
                 <>
-                    <div className="page--header" style={{ marginTop: '4em', display: 'flex', flexDirection: 'column', gap: '1em' }}>
+                    <div className="page--header" style={{ display: 'flex', flexDirection: 'column', gap: '1em' }}>
                         <Typography variant="h5">Inventory</Typography>
                         <Paper variant="outlined" sx={{ padding: '2px' }}>
                             <Typography variant="body1">

--- a/src/components/NotificationCard.module.css
+++ b/src/components/NotificationCard.module.css
@@ -2,8 +2,8 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    margin-bottom: 8px;
-    border-radius: 25px;
+    margin-bottom: 4px;
+    border-radius: 8px;
 }
 
 .notification-card--no-btn {
@@ -26,7 +26,7 @@
 }
 
 .notification-card--image {
-    width: 160px;
+    width: 100px;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -164,7 +164,7 @@ const NotificationCard = (props: NotificationCardProps) => {
     return (
         <ProtectedAdminRoute>
             {type === 'pending-donation' && donation && (
-                <Card className={styles['notification-card']} raised>
+                <Card className={styles['notification-card']} variant="outlined">
                     <div className={styles['notification-card--group']}>
                         <CardActions className={styles['notification-card--image']} onClick={() => setIdToDisplay(donation.id)}>
                             <CardMedia component="img" alt={donation.model} image={donation.images[0]} />
@@ -187,7 +187,7 @@ const NotificationCard = (props: NotificationCardProps) => {
                     {isLoading ? (
                         <Loader />
                     ) : (
-                        <Card className={styles['notification-card']} raised>
+                        <Card className={styles['notification-card']} variant="outlined">
                             <div className={styles['notification-card--group']}>
                                 <CardActions className={styles['notification-card--image']} onClick={() => setIdToDisplay(donation.id)}>
                                     <CardMedia component="img" alt={donation.model} image={donation.images[0]} />
@@ -226,7 +226,7 @@ const NotificationCard = (props: NotificationCardProps) => {
                     {isLoading ? (
                         <Loader />
                     ) : (
-                        <Card className={styles['notification-card']} raised>
+                        <Card className={styles['notification-card']} variant="outlined">
                             <div className={styles['notification-card--group']}>
                                 <CardActions className={styles['notification-card--image']} onClick={() => setIdToDisplay(donation.id)}>
                                     <CardMedia component="img" alt={donation.model} image={donation.images[0]} />
@@ -263,7 +263,7 @@ const NotificationCard = (props: NotificationCardProps) => {
                 </>
             )}
             {type === 'order' && donation && (
-                <Card className={styles['notification-card']} raised>
+                <Card className={styles['notification-card']} variant="outlined">
                     <div className={styles['notification-card--group']}>
                         <CardActions className={styles['notification-card--image']} onClick={() => setIdToDisplay(donation.id)}>
                             <CardMedia component="img" alt={donation.model} image={donation.images[0]} />
@@ -287,7 +287,7 @@ const NotificationCard = (props: NotificationCardProps) => {
                         <Loader />
                     ) : (
                         <>
-                            <Card className={styles['notification-card']} raised>
+                            <Card className={styles['notification-card']} variant="outlined">
                                 <CardActions onClick={() => setIdToDisplay(user.uid)} sx={{ width: '100%' }}>
                                     <CardContent className={styles['notification-card--info']}>
                                         <Typography variant="h5">{user.displayName}</Typography>

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -41,7 +41,7 @@ type RequestorGroup = {
 const groupByDonor = (donations: Donation[]): DonorGroup[] => {
     const bulkMap = new Map<string, Donation[]>();
     for (const d of donations) {
-        const key = d.bulkCollection;
+        const key = d.bulkCollection || `standalone-${d.id}`;
         if (!bulkMap.has(key)) bulkMap.set(key, []);
         bulkMap.get(key)!.push(d);
     }

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -9,47 +9,79 @@ import DonationDetails from '@/components/DonationDetails';
 import ReviewOrder from './ReviewOrder';
 import NotificationCard from '@/components/NotificationCard';
 import CustomTabPanel from './CustomTabPanel';
-import { Box, Button, Chip, Paper, Tab, Tabs, Typography } from '@mui/material';
+import { Box, Button, Chip, Divider, Paper, Tab, Tabs, Typography } from '@mui/material';
 //Styles
 import '@/styles/globalStyles.css';
 import styles from '@/components/NotificationCard.module.css';
 //Types
 import { Notification } from '@/types/NotificationTypes';
 import { Donation } from '@/models/donation';
+import { Order } from '@/types/OrdersTypes';
 
 type NotificationsProps = {
     notifications: Notification;
     setNotificationsUpdated?: Dispatch<SetStateAction<boolean>>;
 };
 
-const sortArrayByBulkId = (array: Donation[]): Donation[][] => {
-    const groupedByField = array.reduce(
-        (acc, item) => {
-            const sortByField = item.bulkCollection;
-            if (!acc[sortByField]) {
-                acc[sortByField] = [];
-            }
-            acc[sortByField].push(item);
-            return acc;
-        },
-        {} as Record<string, Donation[]>
-    );
-    return Object.values(groupedByField);
+type DonorGroup = {
+    donorName: string;
+    donorEmail: string;
+    donorId: string;
+    submissions: Donation[][];
+    totalItems: number;
 };
 
-const sortArrayByRequestor = (array: Donation[]): Donation[][] => {
-    const groupedByField = array.reduce(
-        (acc, item) => {
-            const sortByField = item.requestor ? item.requestor.id : '';
-            if (!acc[sortByField]) {
-                acc[sortByField] = [];
-            }
-            acc[sortByField].push(item);
-            return acc;
-        },
-        {} as Record<string, Donation[]>
-    );
-    return Object.values(groupedByField);
+type RequestorGroup = {
+    requestorName: string;
+    requestorId: string;
+    orders: Order[];
+    totalItems: number;
+};
+
+const groupByDonor = (donations: Donation[]): DonorGroup[] => {
+    const bulkMap = new Map<string, Donation[]>();
+    for (const d of donations) {
+        const key = d.bulkCollection;
+        if (!bulkMap.has(key)) bulkMap.set(key, []);
+        bulkMap.get(key)!.push(d);
+    }
+
+    const donorMap = new Map<string, { donorName: string; donorEmail: string; submissions: Donation[][] }>();
+    for (const bulk of bulkMap.values()) {
+        const { donorId, donorName, donorEmail } = bulk[0];
+        if (!donorMap.has(donorId)) {
+            donorMap.set(donorId, { donorName, donorEmail, submissions: [] });
+        }
+        donorMap.get(donorId)!.submissions.push(bulk);
+    }
+
+    return Array.from(donorMap.entries())
+        .map(([donorId, data]) => ({
+            donorId,
+            donorName: data.donorName,
+            donorEmail: data.donorEmail,
+            submissions: data.submissions,
+            totalItems: data.submissions.reduce((sum, s) => sum + s.length, 0),
+        }))
+        .sort((a, b) => a.donorName.localeCompare(b.donorName));
+};
+
+const groupByRequestor = (orders: Order[]): RequestorGroup[] => {
+    const map = new Map<string, { name: string; orders: Order[] }>();
+    for (const order of orders) {
+        const { id, name } = order.requestor;
+        if (!map.has(id)) map.set(id, { name, orders: [] });
+        map.get(id)!.orders.push(order);
+    }
+
+    return Array.from(map.entries())
+        .map(([requestorId, data]) => ({
+            requestorId,
+            requestorName: data.name,
+            orders: data.orders,
+            totalItems: data.orders.reduce((sum, o) => sum + o.items.length, 0),
+        }))
+        .sort((a, b) => a.requestorName.localeCompare(b.requestorName));
 };
 
 const Notifications = (props: NotificationsProps) => {
@@ -61,15 +93,13 @@ const Notifications = (props: NotificationsProps) => {
     const [currentTab, setCurrentTab] = useState<number>(0);
 
     const donationsAwaitingApproval = notifications.donations.filter((donation) => donation.status === 'in processing');
-    const sortedDonationsWaitingApproval = sortArrayByBulkId(donationsAwaitingApproval);
+    const donorGroupsApproval = groupByDonor(donationsAwaitingApproval);
     const donationsAwaitingDropoff = notifications.donations.filter((donation) => donation.status === 'pending delivery');
-    const sortedDonationsAwaitingDropoff = sortArrayByBulkId(donationsAwaitingDropoff);
+    const donorGroupsDelivery = groupByDonor(donationsAwaitingDropoff);
     const donationsAwaitingPickup = notifications.donations.filter((donation) => donation.status === 'reserved');
-    const sortedDonationsAwaitingPickup = sortArrayByBulkId(donationsAwaitingPickup);
+    const donorGroupsPickup = groupByDonor(donationsAwaitingPickup);
     const orders = notifications.orders.filter((order) => order.items.length > 0);
-    const sortedOrders = [...orders].sort((a, b) =>
-        a.requestor.name.localeCompare(b.requestor.name)
-    );
+    const requestorGroups = groupByRequestor(orders);
     const usersAwaitingApproval = notifications.users.filter((user) => !user.isDeleted);
 
     const router = useRouter();
@@ -77,10 +107,19 @@ const Notifications = (props: NotificationsProps) => {
     const tabConfig = [
         { label: 'Pending Approval', count: donationsAwaitingApproval.length },
         { label: 'Pending Delivery', count: donationsAwaitingDropoff.length },
-        { label: 'Requested', count: sortedOrders.length },
+        { label: 'Requested', count: orders.length },
         { label: 'Pending Pickup', count: donationsAwaitingPickup.length },
         { label: 'Pending Users', count: usersAwaitingApproval.length },
     ];
+
+    const donorHeader = (name: string, count: number) => (
+        <Typography variant="body2" fontWeight={600}>
+            {name}
+            <Typography component="span" variant="body2" color="text.secondary">
+                {` — ${count} item${count !== 1 ? 's' : ''}`}
+            </Typography>
+        </Typography>
+    );
 
     return (
         <ProtectedAdminRoute>
@@ -145,37 +184,75 @@ const Notifications = (props: NotificationsProps) => {
                                 ))}
                             </Tabs>
 
+                            {/* Tab 0: Pending Approval — grouped by donor, sub-grouped by bulk submission */}
                             <CustomTabPanel value={currentTab} index={0}>
-                                {sortedDonationsWaitingApproval.length > 0 ? (
-                                    sortedDonationsWaitingApproval.map((donationArray, i) => (
-                                        <Paper key={i} variant="outlined" sx={{ mb: 2, overflow: 'hidden' }}>
-                                            <Box sx={{
-                                                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                                                bgcolor: '#f5f5f5', px: 2, py: 1, borderBottom: '1px solid #e0e0e0',
-                                            }}>
-                                                <Typography variant="body2" fontWeight={600}>
-                                                    {donationArray[0].donorName}
-                                                    <Typography component="span" variant="body2" color="text.secondary">
-                                                        {` — ${donationArray.length} item${donationArray.length !== 1 ? 's' : ''}`}
-                                                    </Typography>
-                                                </Typography>
-                                                <Button
-                                                    size="small"
-                                                    variant="contained"
-                                                    onClick={() => router.push(`/accept/${donationArray[0].bulkCollection}`)}
-                                                >
-                                                    Review
-                                                </Button>
-                                            </Box>
-                                            {donationArray.map((donation) => (
-                                                <NotificationCard
-                                                    key={donation.id}
-                                                    donation={donation}
-                                                    type="pending-donation"
-                                                    setIdToDisplay={setDonationIdToDisplay}
-                                                    setNotificationsUpdated={setNotificationsUpdated}
-                                                />
-                                            ))}
+                                {donorGroupsApproval.length > 0 ? (
+                                    donorGroupsApproval.map((group) => (
+                                        <Paper key={group.donorId} variant="outlined" sx={{ mb: 2, overflow: 'hidden' }}>
+                                            {group.submissions.length === 1 ? (
+                                                <>
+                                                    <Box sx={{
+                                                        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                                                        bgcolor: '#f5f5f5', px: 2, py: 1, borderBottom: '1px solid #e0e0e0',
+                                                    }}>
+                                                        {donorHeader(group.donorName, group.totalItems)}
+                                                        <Button
+                                                            size="small"
+                                                            variant="contained"
+                                                            onClick={() => router.push(`/accept/${group.submissions[0][0].bulkCollection}`)}
+                                                        >
+                                                            Review
+                                                        </Button>
+                                                    </Box>
+                                                    {group.submissions[0].map((donation) => (
+                                                        <NotificationCard
+                                                            key={donation.id}
+                                                            donation={donation}
+                                                            type="pending-donation"
+                                                            setIdToDisplay={setDonationIdToDisplay}
+                                                            setNotificationsUpdated={setNotificationsUpdated}
+                                                        />
+                                                    ))}
+                                                </>
+                                            ) : (
+                                                <>
+                                                    <Box sx={{
+                                                        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                                                        bgcolor: '#f5f5f5', px: 2, py: 1, borderBottom: '1px solid #e0e0e0',
+                                                    }}>
+                                                        {donorHeader(group.donorName, group.totalItems)}
+                                                    </Box>
+                                                    {group.submissions.map((submission, si) => (
+                                                        <Box key={submission[0].bulkCollection}>
+                                                            {si > 0 && <Divider />}
+                                                            <Box sx={{
+                                                                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                                                                bgcolor: '#fafafa', px: 2, py: 0.75, borderBottom: '1px solid #f0f0f0',
+                                                            }}>
+                                                                <Typography variant="caption" color="text.secondary">
+                                                                    {`${submission.length} item${submission.length !== 1 ? 's' : ''}`}
+                                                                </Typography>
+                                                                <Button
+                                                                    size="small"
+                                                                    variant="contained"
+                                                                    onClick={() => router.push(`/accept/${submission[0].bulkCollection}`)}
+                                                                >
+                                                                    Review
+                                                                </Button>
+                                                            </Box>
+                                                            {submission.map((donation) => (
+                                                                <NotificationCard
+                                                                    key={donation.id}
+                                                                    donation={donation}
+                                                                    type="pending-donation"
+                                                                    setIdToDisplay={setDonationIdToDisplay}
+                                                                    setNotificationsUpdated={setNotificationsUpdated}
+                                                                />
+                                                            ))}
+                                                        </Box>
+                                                    ))}
+                                                </>
+                                            )}
                                         </Paper>
                                     ))
                                 ) : (
@@ -185,22 +262,18 @@ const Notifications = (props: NotificationsProps) => {
                                 )}
                             </CustomTabPanel>
 
+                            {/* Tab 1: Pending Delivery — grouped by donor, flat card list */}
                             <CustomTabPanel value={currentTab} index={1}>
-                                {sortedDonationsAwaitingDropoff.length > 0 ? (
-                                    sortedDonationsAwaitingDropoff.map((donationArray, i) => (
-                                        <Paper key={i} variant="outlined" sx={{ mb: 2, overflow: 'hidden' }}>
+                                {donorGroupsDelivery.length > 0 ? (
+                                    donorGroupsDelivery.map((group) => (
+                                        <Paper key={group.donorId} variant="outlined" sx={{ mb: 2, overflow: 'hidden' }}>
                                             <Box sx={{
                                                 display: 'flex', alignItems: 'center', justifyContent: 'space-between',
                                                 bgcolor: '#f5f5f5', px: 2, py: 1, borderBottom: '1px solid #e0e0e0',
                                             }}>
-                                                <Typography variant="body2" fontWeight={600}>
-                                                    {donationArray[0].donorName}
-                                                    <Typography component="span" variant="body2" color="text.secondary">
-                                                        {` — ${donationArray.length} item${donationArray.length !== 1 ? 's' : ''}`}
-                                                    </Typography>
-                                                </Typography>
+                                                {donorHeader(group.donorName, group.totalItems)}
                                             </Box>
-                                            {donationArray.map((donation) => (
+                                            {group.submissions.flat().map((donation) => (
                                                 <NotificationCard
                                                     key={donation.id}
                                                     donation={donation}
@@ -218,37 +291,81 @@ const Notifications = (props: NotificationsProps) => {
                                 )}
                             </CustomTabPanel>
 
+                            {/* Tab 2: Requested — grouped by requestor, sub-grouped by order */}
                             <CustomTabPanel value={currentTab} index={2}>
-                                {sortedOrders.length > 0 ? (
-                                    sortedOrders.map((order) => (
-                                        <Paper key={order.id} variant="outlined" sx={{ mb: 2, overflow: 'hidden' }}>
-                                            <Box sx={{
-                                                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                                                bgcolor: '#f5f5f5', px: 2, py: 1, borderBottom: '1px solid #e0e0e0',
-                                            }}>
-                                                <Typography variant="body2" fontWeight={600}>
-                                                    {order.requestor.name}
-                                                    <Typography component="span" variant="body2" color="text.secondary">
-                                                        {` — ${order.items.length} item${order.items.length !== 1 ? 's' : ''}`}
-                                                    </Typography>
-                                                </Typography>
-                                                <Button
-                                                    size="small"
-                                                    variant="contained"
-                                                    onClick={() => setOrderIdToDisplay(order.id)}
-                                                >
-                                                    Review
-                                                </Button>
-                                            </Box>
-                                            {order.items.map((item) => (
-                                                <NotificationCard
-                                                    key={item.id}
-                                                    type="order"
-                                                    donation={item}
-                                                    setIdToDisplay={setDonationIdToDisplay}
-                                                    setNotificationsUpdated={setNotificationsUpdated}
-                                                />
-                                            ))}
+                                {requestorGroups.length > 0 ? (
+                                    requestorGroups.map((group) => (
+                                        <Paper key={group.requestorId} variant="outlined" sx={{ mb: 2, overflow: 'hidden' }}>
+                                            {group.orders.length === 1 ? (
+                                                <>
+                                                    <Box sx={{
+                                                        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                                                        bgcolor: '#f5f5f5', px: 2, py: 1, borderBottom: '1px solid #e0e0e0',
+                                                    }}>
+                                                        {donorHeader(group.requestorName, group.totalItems)}
+                                                        <Button
+                                                            size="small"
+                                                            variant="contained"
+                                                            onClick={() => setOrderIdToDisplay(group.orders[0].id)}
+                                                        >
+                                                            Review
+                                                        </Button>
+                                                    </Box>
+                                                    {group.orders[0].items.map((item) => (
+                                                        <NotificationCard
+                                                            key={item.id}
+                                                            type="order"
+                                                            donation={item}
+                                                            setIdToDisplay={setDonationIdToDisplay}
+                                                            setNotificationsUpdated={setNotificationsUpdated}
+                                                        />
+                                                    ))}
+                                                </>
+                                            ) : (
+                                                <>
+                                                    <Box sx={{
+                                                        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                                                        bgcolor: '#f5f5f5', px: 2, py: 1, borderBottom: '1px solid #e0e0e0',
+                                                    }}>
+                                                        <Typography variant="body2" fontWeight={600}>
+                                                            {group.requestorName}
+                                                            <Typography component="span" variant="body2" color="text.secondary">
+                                                                {` — ${group.orders.length} orders, ${group.totalItems} item${group.totalItems !== 1 ? 's' : ''}`}
+                                                            </Typography>
+                                                        </Typography>
+                                                    </Box>
+                                                    {group.orders.map((order, oi) => (
+                                                        <Box key={order.id}>
+                                                            {oi > 0 && <Divider />}
+                                                            <Box sx={{
+                                                                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                                                                bgcolor: '#fafafa', px: 2, py: 0.75, borderBottom: '1px solid #f0f0f0',
+                                                            }}>
+                                                                <Typography variant="caption" color="text.secondary">
+                                                                    {`${order.items.length} item${order.items.length !== 1 ? 's' : ''}`}
+                                                                    {order.createdAt && ` — ${order.createdAt.toDate().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`}
+                                                                </Typography>
+                                                                <Button
+                                                                    size="small"
+                                                                    variant="contained"
+                                                                    onClick={() => setOrderIdToDisplay(order.id)}
+                                                                >
+                                                                    Review
+                                                                </Button>
+                                                            </Box>
+                                                            {order.items.map((item) => (
+                                                                <NotificationCard
+                                                                    key={item.id}
+                                                                    type="order"
+                                                                    donation={item}
+                                                                    setIdToDisplay={setDonationIdToDisplay}
+                                                                    setNotificationsUpdated={setNotificationsUpdated}
+                                                                />
+                                                            ))}
+                                                        </Box>
+                                                    ))}
+                                                </>
+                                            )}
                                         </Paper>
                                     ))
                                 ) : (
@@ -258,22 +375,18 @@ const Notifications = (props: NotificationsProps) => {
                                 )}
                             </CustomTabPanel>
 
+                            {/* Tab 3: Pending Pickup — grouped by donor, flat card list */}
                             <CustomTabPanel value={currentTab} index={3}>
-                                {sortedDonationsAwaitingPickup.length > 0 ? (
-                                    sortedDonationsAwaitingPickup.map((donationArray, i) => (
-                                        <Paper key={i} variant="outlined" sx={{ mb: 2, overflow: 'hidden' }}>
+                                {donorGroupsPickup.length > 0 ? (
+                                    donorGroupsPickup.map((group) => (
+                                        <Paper key={group.donorId} variant="outlined" sx={{ mb: 2, overflow: 'hidden' }}>
                                             <Box sx={{
                                                 display: 'flex', alignItems: 'center', justifyContent: 'space-between',
                                                 bgcolor: '#f5f5f5', px: 2, py: 1, borderBottom: '1px solid #e0e0e0',
                                             }}>
-                                                <Typography variant="body2" fontWeight={600}>
-                                                    {donationArray[0].donorName}
-                                                    <Typography component="span" variant="body2" color="text.secondary">
-                                                        {` — ${donationArray.length} item${donationArray.length !== 1 ? 's' : ''}`}
-                                                    </Typography>
-                                                </Typography>
+                                                {donorHeader(group.donorName, group.totalItems)}
                                             </Box>
-                                            {donationArray.map((donation) => (
+                                            {group.submissions.flat().map((donation) => (
                                                 <NotificationCard
                                                     key={donation.id}
                                                     donation={donation}
@@ -291,6 +404,7 @@ const Notifications = (props: NotificationsProps) => {
                                 )}
                             </CustomTabPanel>
 
+                            {/* Tab 4: Pending Users — no grouping */}
                             <CustomTabPanel value={currentTab} index={4}>
                                 {usersAwaitingApproval.length > 0 ? (
                                     usersAwaitingApproval.map((user) => (

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -8,7 +8,8 @@ import UserDetails from '@/components/UserDetails';
 import DonationDetails from '@/components/DonationDetails';
 import ReviewOrder from './ReviewOrder';
 import NotificationCard from '@/components/NotificationCard';
-import { Button, Paper, Typography } from '@mui/material';
+import CustomTabPanel from './CustomTabPanel';
+import { Box, Button, Chip, Paper, Tab, Tabs, Typography } from '@mui/material';
 //Styles
 import '@/styles/globalStyles.css';
 import styles from '@/components/NotificationCard.module.css';
@@ -57,6 +58,7 @@ const Notifications = (props: NotificationsProps) => {
     const [donationIdToDisplay, setDonationIdToDisplay] = useState<string | null>(null);
     const [userIdToDisplay, setUserIdToDisplay] = useState<string | null>(null);
     const [orderIdToDisplay, setOrderIdToDisplay] = useState<string | null>(null);
+    const [currentTab, setCurrentTab] = useState<number>(0);
 
     const donationsAwaitingApproval = notifications.donations.filter((donation) => donation.status === 'in processing');
     const sortedDonationsWaitingApproval = sortArrayByBulkId(donationsAwaitingApproval);
@@ -65,9 +67,20 @@ const Notifications = (props: NotificationsProps) => {
     const donationsAwaitingPickup = notifications.donations.filter((donation) => donation.status === 'reserved');
     const sortedDonationsAwaitingPickup = sortArrayByBulkId(donationsAwaitingPickup);
     const orders = notifications.orders.filter((order) => order.items.length > 0);
-    const usersAwaitingApproval = notifications.users.filter((user) => !user.isDeleted); //Filters out recently deleted users
+    const sortedOrders = [...orders].sort((a, b) =>
+        a.requestor.name.localeCompare(b.requestor.name)
+    );
+    const usersAwaitingApproval = notifications.users.filter((user) => !user.isDeleted);
 
     const router = useRouter();
+
+    const tabConfig = [
+        { label: 'Pending Approval', count: donationsAwaitingApproval.length },
+        { label: 'Pending Delivery', count: donationsAwaitingDropoff.length },
+        { label: 'Requested', count: sortedOrders.length },
+        { label: 'Pending Pickup', count: donationsAwaitingPickup.length },
+        { label: 'Pending Users', count: usersAwaitingApproval.length },
+    ];
 
     return (
         <ProtectedAdminRoute>
@@ -76,127 +89,225 @@ const Notifications = (props: NotificationsProps) => {
             {orderIdToDisplay && (
                 <ReviewOrder
                     id={orderIdToDisplay}
-                    // order={orders.find((o) => o.id === orderIdToDisplay)}
                     setIdToDisplay={setOrderIdToDisplay}
                     setNotificationsUpdated={setNotificationsUpdated}
                 />
             )}
             {!donationIdToDisplay && !userIdToDisplay && !orderIdToDisplay && (
                 <>
-                    {notifications.donations.length === 0 && notifications.orders.length === 0 && notifications.users.length === 0 && (
+                    {notifications.donations.length === 0 && notifications.orders.length === 0 && notifications.users.length === 0 ? (
                         <Typography sx={{ marginTop: '1rem' }} variant="body1">
                             No new notifications at this time.
                         </Typography>
-                    )}
-                    {sortedDonationsWaitingApproval.length > 0 && (
+                    ) : (
                         <>
-                            <Typography sx={{ marginTop: '1rem' }} variant="h6">
-                                Donations requiring approval
-                            </Typography>
-                            {sortedDonationsWaitingApproval.map((donationArray, i) => (
-                                <Paper className={styles['notification-card--container']} key={i} elevation={3}>
-                                    {donationArray.map((donation) => (
+                            <Tabs
+                                value={currentTab}
+                                onChange={(_, v) => setCurrentTab(v)}
+                                variant="scrollable"
+                                scrollButtons="auto"
+                                sx={{
+                                    borderBottom: 1,
+                                    borderColor: 'divider',
+                                    minHeight: 40,
+                                    '& .MuiTab-root': {
+                                        textTransform: 'none',
+                                        fontSize: '0.8125rem',
+                                        fontWeight: 500,
+                                        minHeight: 40,
+                                        py: 0.5,
+                                    },
+                                    '& .Mui-selected': { color: '#3d9991' },
+                                    '& .MuiTabs-indicator': { backgroundColor: '#3d9991' },
+                                }}
+                            >
+                                {tabConfig.map((tab) => (
+                                    <Tab
+                                        key={tab.label}
+                                        label={
+                                            <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                                                {tab.label}
+                                                <Chip
+                                                    label={tab.count}
+                                                    size="small"
+                                                    sx={{
+                                                        height: 20,
+                                                        minWidth: 20,
+                                                        fontSize: '0.6875rem',
+                                                        fontWeight: 700,
+                                                        bgcolor: tab.count > 0 ? '#a8351b' : '#e0e0e0',
+                                                        color: tab.count > 0 ? '#fff' : '#757575',
+                                                    }}
+                                                />
+                                            </span>
+                                        }
+                                    />
+                                ))}
+                            </Tabs>
+
+                            <CustomTabPanel value={currentTab} index={0}>
+                                {sortedDonationsWaitingApproval.length > 0 ? (
+                                    sortedDonationsWaitingApproval.map((donationArray, i) => (
+                                        <Paper key={i} variant="outlined" sx={{ mb: 2, overflow: 'hidden' }}>
+                                            <Box sx={{
+                                                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                                                bgcolor: '#f5f5f5', px: 2, py: 1, borderBottom: '1px solid #e0e0e0',
+                                            }}>
+                                                <Typography variant="body2" fontWeight={600}>
+                                                    {donationArray[0].donorName}
+                                                    <Typography component="span" variant="body2" color="text.secondary">
+                                                        {` — ${donationArray.length} item${donationArray.length !== 1 ? 's' : ''}`}
+                                                    </Typography>
+                                                </Typography>
+                                                <Button
+                                                    size="small"
+                                                    variant="contained"
+                                                    onClick={() => router.push(`/accept/${donationArray[0].bulkCollection}`)}
+                                                >
+                                                    Review
+                                                </Button>
+                                            </Box>
+                                            {donationArray.map((donation) => (
+                                                <NotificationCard
+                                                    key={donation.id}
+                                                    donation={donation}
+                                                    type="pending-donation"
+                                                    setIdToDisplay={setDonationIdToDisplay}
+                                                    setNotificationsUpdated={setNotificationsUpdated}
+                                                />
+                                            ))}
+                                        </Paper>
+                                    ))
+                                ) : (
+                                    <Typography sx={{ marginTop: '1rem' }} variant="body2" color="text.secondary">
+                                        No donations awaiting approval.
+                                    </Typography>
+                                )}
+                            </CustomTabPanel>
+
+                            <CustomTabPanel value={currentTab} index={1}>
+                                {sortedDonationsAwaitingDropoff.length > 0 ? (
+                                    sortedDonationsAwaitingDropoff.map((donationArray, i) => (
+                                        <Paper key={i} variant="outlined" sx={{ mb: 2, overflow: 'hidden' }}>
+                                            <Box sx={{
+                                                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                                                bgcolor: '#f5f5f5', px: 2, py: 1, borderBottom: '1px solid #e0e0e0',
+                                            }}>
+                                                <Typography variant="body2" fontWeight={600}>
+                                                    {donationArray[0].donorName}
+                                                    <Typography component="span" variant="body2" color="text.secondary">
+                                                        {` — ${donationArray.length} item${donationArray.length !== 1 ? 's' : ''}`}
+                                                    </Typography>
+                                                </Typography>
+                                            </Box>
+                                            {donationArray.map((donation) => (
+                                                <NotificationCard
+                                                    key={donation.id}
+                                                    donation={donation}
+                                                    type="pending-delivery"
+                                                    setIdToDisplay={setDonationIdToDisplay}
+                                                    setNotificationsUpdated={setNotificationsUpdated}
+                                                />
+                                            ))}
+                                        </Paper>
+                                    ))
+                                ) : (
+                                    <Typography sx={{ marginTop: '1rem' }} variant="body2" color="text.secondary">
+                                        No donations awaiting delivery.
+                                    </Typography>
+                                )}
+                            </CustomTabPanel>
+
+                            <CustomTabPanel value={currentTab} index={2}>
+                                {sortedOrders.length > 0 ? (
+                                    sortedOrders.map((order) => (
+                                        <Paper key={order.id} variant="outlined" sx={{ mb: 2, overflow: 'hidden' }}>
+                                            <Box sx={{
+                                                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                                                bgcolor: '#f5f5f5', px: 2, py: 1, borderBottom: '1px solid #e0e0e0',
+                                            }}>
+                                                <Typography variant="body2" fontWeight={600}>
+                                                    {order.requestor.name}
+                                                    <Typography component="span" variant="body2" color="text.secondary">
+                                                        {` — ${order.items.length} item${order.items.length !== 1 ? 's' : ''}`}
+                                                    </Typography>
+                                                </Typography>
+                                                <Button
+                                                    size="small"
+                                                    variant="contained"
+                                                    onClick={() => setOrderIdToDisplay(order.id)}
+                                                >
+                                                    Review
+                                                </Button>
+                                            </Box>
+                                            {order.items.map((item) => (
+                                                <NotificationCard
+                                                    key={item.id}
+                                                    type="order"
+                                                    donation={item}
+                                                    setIdToDisplay={setDonationIdToDisplay}
+                                                    setNotificationsUpdated={setNotificationsUpdated}
+                                                />
+                                            ))}
+                                        </Paper>
+                                    ))
+                                ) : (
+                                    <Typography sx={{ marginTop: '1rem' }} variant="body2" color="text.secondary">
+                                        No equipment requests.
+                                    </Typography>
+                                )}
+                            </CustomTabPanel>
+
+                            <CustomTabPanel value={currentTab} index={3}>
+                                {sortedDonationsAwaitingPickup.length > 0 ? (
+                                    sortedDonationsAwaitingPickup.map((donationArray, i) => (
+                                        <Paper key={i} variant="outlined" sx={{ mb: 2, overflow: 'hidden' }}>
+                                            <Box sx={{
+                                                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                                                bgcolor: '#f5f5f5', px: 2, py: 1, borderBottom: '1px solid #e0e0e0',
+                                            }}>
+                                                <Typography variant="body2" fontWeight={600}>
+                                                    {donationArray[0].donorName}
+                                                    <Typography component="span" variant="body2" color="text.secondary">
+                                                        {` — ${donationArray.length} item${donationArray.length !== 1 ? 's' : ''}`}
+                                                    </Typography>
+                                                </Typography>
+                                            </Box>
+                                            {donationArray.map((donation) => (
+                                                <NotificationCard
+                                                    key={donation.id}
+                                                    donation={donation}
+                                                    type="reserved"
+                                                    setIdToDisplay={setDonationIdToDisplay}
+                                                    setNotificationsUpdated={setNotificationsUpdated}
+                                                />
+                                            ))}
+                                        </Paper>
+                                    ))
+                                ) : (
+                                    <Typography sx={{ marginTop: '1rem' }} variant="body2" color="text.secondary">
+                                        No donations awaiting pickup.
+                                    </Typography>
+                                )}
+                            </CustomTabPanel>
+
+                            <CustomTabPanel value={currentTab} index={4}>
+                                {usersAwaitingApproval.length > 0 ? (
+                                    usersAwaitingApproval.map((user) => (
                                         <NotificationCard
-                                            key={donation.id}
-                                            donation={donation}
-                                            type="pending-donation"
-                                            setIdToDisplay={setDonationIdToDisplay}
+                                            key={user.uid}
+                                            type="pending-user"
+                                            user={user}
+                                            setIdToDisplay={setUserIdToDisplay}
                                             setNotificationsUpdated={setNotificationsUpdated}
                                         />
-                                    ))}
-                                    <Button
-                                        className={styles['notification-card--container--btn']}
-                                        variant="contained"
-                                        onClick={() => router.push(`/accept/${donationArray[0].bulkCollection}`)}
-                                    >
-                                        Review
-                                    </Button>
-                                </Paper>
-                            ))}
-                        </>
-                    )}
-                    {sortedDonationsAwaitingDropoff.length > 0 && (
-                        <>
-                            <Typography sx={{ marginTop: '1rem' }} variant="h6">
-                                Donations waiting to be received
-                            </Typography>
-                            {sortedDonationsAwaitingDropoff.map((donationArray, i) => (
-                                <Paper className={styles['notification-card--container']} key={i} elevation={3}>
-                                    {donationArray.map((donation) => (
-                                        <NotificationCard
-                                            key={donation.id}
-                                            donation={donation}
-                                            type="pending-delivery"
-                                            setIdToDisplay={setDonationIdToDisplay}
-                                            setNotificationsUpdated={setNotificationsUpdated}
-                                        />
-                                    ))}
-                                </Paper>
-                            ))}
-                        </>
-                    )}
-                    {sortedDonationsAwaitingPickup.length > 0 && (
-                        <>
-                            <Typography sx={{ marginTop: '1rem' }} variant="h6">
-                                Donations waiting for pickup
-                            </Typography>
-                            {sortedDonationsAwaitingPickup.map((donationArray, i) => (
-                                <Paper className={styles['notification-card--container']} key={i} elevation={3}>
-                                    {donationArray.map((donation) => (
-                                        <NotificationCard
-                                            key={donation.id}
-                                            donation={donation}
-                                            type="reserved"
-                                            setIdToDisplay={setDonationIdToDisplay}
-                                            setNotificationsUpdated={setNotificationsUpdated}
-                                        />
-                                    ))}
-                                </Paper>
-                            ))}
-                        </>
-                    )}
-                    {orders.length > 0 && (
-                        <>
-                            <Typography sx={{ marginTop: '1rem' }} variant="h6">
-                                Requested Equipment
-                            </Typography>
-                            {orders.map((order) => (
-                                <Paper className={styles['notification-card--container']} key={order.id} elevation={3}>
-                                    <Typography variant="h6">{`${order.requestor.name} has requested the following items:`}</Typography>
-                                    {order.items.map((item) => (
-                                        <NotificationCard
-                                            key={item.id}
-                                            type="order"
-                                            donation={item}
-                                            setIdToDisplay={setDonationIdToDisplay}
-                                            setNotificationsUpdated={setNotificationsUpdated}
-                                        />
-                                    ))}
-                                    <Button
-                                        className={styles['notification-card--container--btn']}
-                                        variant="contained"
-                                        onClick={() => setOrderIdToDisplay(order.id)}
-                                    >
-                                        Review
-                                    </Button>
-                                </Paper>
-                            ))}
-                        </>
-                    )}
-                    {usersAwaitingApproval.length > 0 && (
-                        <>
-                            <Typography sx={{ marginTop: '1rem' }} variant="h6">
-                                Users awaiting approval
-                            </Typography>
-                            {usersAwaitingApproval.map((user) => (
-                                <NotificationCard
-                                    key={user.uid}
-                                    type="pending-user"
-                                    user={user}
-                                    setIdToDisplay={setUserIdToDisplay}
-                                    setNotificationsUpdated={setNotificationsUpdated}
-                                />
-                            ))}
+                                    ))
+                                ) : (
+                                    <Typography sx={{ marginTop: '1rem' }} variant="body2" color="text.secondary">
+                                        No users awaiting approval.
+                                    </Typography>
+                                )}
+                            </CustomTabPanel>
                         </>
                     )}
                 </>

--- a/src/components/ScheduleDropOff.tsx
+++ b/src/components/ScheduleDropOff.tsx
@@ -6,7 +6,7 @@ import { renderToString } from 'react-dom/server';
 import { useRouter } from 'next/navigation';
 //Components
 import ProtectedAdminRoute from './ProtectedAdminRoute';
-import { Box, Button, FormControl, NativeSelect, TextField, InputLabel } from '@mui/material';
+import { Alert, Box, Button, FormControl, InputLabel, MenuItem, NativeSelect, Select, TextField, Typography } from '@mui/material';
 import DonationCardSmall from './DonationCardSmall';
 import Loader from './Loader';
 import CustomDialog from './CustomDialog';
@@ -18,18 +18,26 @@ import posthog from 'posthog-js';
 import accept from '@/email-templates/accept';
 import reject from '@/email-templates/reject';
 import { updateDonation, updateDonationStatus } from '@/api/firebase-donations';
-import { getTagNumber } from '@/api/firebase-categories';
+import { getAllCategories, getTagNumber } from '@/api/firebase-categories';
 //Styles
 import '@/styles/globalStyles.css';
 //types
 import { EventType } from '@/types/CalendlyTypes';
 import { Donation } from '@/models/donation';
+import { Category } from '@/models/category';
 import { serverTimestamp } from 'firebase/firestore';
 
 type ScheduleDropOffProps = {
     acceptedDonations?: Donation[];
     rejectedDonations?: Donation[];
     setOpenScheduler: Dispatch<SetStateAction<boolean>>;
+};
+
+type CategoryError = {
+    id: string;
+    brand: string;
+    model: string;
+    invalidCategory: string;
 };
 
 const ScheduleDropOff = (props: ScheduleDropOffProps) => {
@@ -40,6 +48,9 @@ const ScheduleDropOff = (props: ScheduleDropOffProps) => {
     const [notes, setNotes] = useState<string>('');
     const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
     const [errorMessage, setErrorMessage] = useState<string>('');
+    const [categories, setCategories] = useState<Category[]>([]);
+    const [categoryErrors, setCategoryErrors] = useState<CategoryError[]>([]);
+    const [categoryOverrides, setCategoryOverrides] = useState<Record<string, string>>({});
 
     const router = useRouter();
 
@@ -75,24 +86,43 @@ const ScheduleDropOff = (props: ScheduleDropOffProps) => {
 
     const acceptPromise = async (donations: Donation[]): Promise<string[]> => {
         const tagNumbers: string[] = [];
-        await Promise.all(
-            donations.map(async (donation) => {
-                try {
-                    const newTagNumber = await getTagNumber(donation.category);
-                    tagNumbers.push(newTagNumber);
-                    await updateDonation(donation.id, {
-                        status: 'pending delivery',
-                        dateAccepted: serverTimestamp(),
-                        tagNumber: newTagNumber
-                    });
-                } catch (error) {
-                    addErrorEvent('Error accepting donation', error);
-                    throw error;
+        const writtenIds: string[] = [];
+
+        try {
+            for (const donation of donations) {
+                const effectiveCategory = categoryOverrides[donation.id] || donation.category;
+                const newTagNumber = await getTagNumber(effectiveCategory);
+                tagNumbers.push(newTagNumber);
+
+                const updates: Record<string, any> = {
+                    status: 'pending delivery',
+                    dateAccepted: serverTimestamp(),
+                    tagNumber: newTagNumber
+                };
+                if (categoryOverrides[donation.id]) {
+                    updates.category = effectiveCategory;
                 }
-            })
-        );
-        return tagNumbers;
+
+                await updateDonation(donation.id, updates);
+                writtenIds.push(donation.id);
+            }
+            return tagNumbers;
+        } catch (error) {
+            for (const id of writtenIds) {
+                try {
+                    await updateDonation(id, {
+                        status: 'in processing',
+                        dateAccepted: null,
+                        tagNumber: null
+                    });
+                } catch (rollbackError) {
+                    addErrorEvent('Rollback failed for donation', rollbackError);
+                }
+            }
+            throw error;
+        }
     };
+
     const rejectPromise = async (donations: Donation[]) => {
         await Promise.all(
             donations.map(async (donation) => {
@@ -129,11 +159,32 @@ const ScheduleDropOff = (props: ScheduleDropOffProps) => {
     );
 
     const handleSubmit = async () => {
-        //send email with renderToString(message) and update donation statuses. If donation is accepted, assign a tagNumber
         setIsLoading(true);
+        setErrorMessage('');
+        setCategoryErrors([]);
+
         try {
             let tagNumbers: string[] = [];
-            if (acceptedDonations) tagNumbers = await acceptPromise(acceptedDonations);
+            if (acceptedDonations && acceptedDonations.length > 0) {
+                if (categories.length > 0) {
+                    const validNames = new Set(categories.map((c) => c.getName()));
+                    const errors: CategoryError[] = acceptedDonations
+                        .filter((d) => !validNames.has(categoryOverrides[d.id] || d.category))
+                        .map((d) => ({
+                            id: d.id,
+                            brand: d.brand,
+                            model: d.model,
+                            invalidCategory: d.category
+                        }));
+
+                    if (errors.length > 0) {
+                        setCategoryErrors(errors);
+                        setIsLoading(false);
+                        return;
+                    }
+                }
+                tagNumbers = await acceptPromise(acceptedDonations);
+            }
             if (rejectedDonations) await rejectPromise(rejectedDonations);
             const emailMsg =
                 acceptedDonations && acceptedDonations.length > 0
@@ -148,19 +199,24 @@ const ScheduleDropOff = (props: ScheduleDropOffProps) => {
         } catch (error) {
             addErrorEvent('Error submitting accept/reject email', error);
             posthog.captureException(error);
-            if (error instanceof Error && error.message.startsWith('Category not found:')) {
-                setErrorMessage(error.message);
-            } else {
-                setErrorMessage('An unexpected error occurred while processing donations. Please try again.');
-            }
+            setErrorMessage('An unexpected error occurred while processing donations. Please try again.');
         } finally {
             setIsLoading(false);
         }
     };
 
+    const handleCategoryOverride = (donationId: string, newCategory: string) => {
+        setCategoryOverrides((prev) => ({ ...prev, [donationId]: newCategory }));
+    };
+
     useEffect(() => {
         fetchEvents();
+        getAllCategories()
+            .then(setCategories)
+            .catch((err) => addErrorEvent('Fetch categories', err));
     }, []);
+
+    const allErrorsCorrected = categoryErrors.length > 0 && categoryErrors.every((err) => categoryOverrides[err.id]);
 
     return (
         <ProtectedAdminRoute>
@@ -175,6 +231,51 @@ const ScheduleDropOff = (props: ScheduleDropOffProps) => {
                     <div className="content--container">
                         <Box display={'flex'} flexDirection={'column'}>
                             {message}
+
+                            {categoryErrors.length > 0 && (
+                                <Alert severity="warning" sx={{ mt: 2, mb: 2 }}>
+                                    <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
+                                        {categoryErrors.length === 1
+                                            ? '1 item has an unrecognized category'
+                                            : `${categoryErrors.length} items have unrecognized categories`}
+                                    </Typography>
+                                    <Typography variant="body2" sx={{ mb: 2 }}>
+                                        Select a valid category for each item, then click &ldquo;Send Email&rdquo; again.
+                                    </Typography>
+                                    {categoryErrors.map((err) => (
+                                        <Box key={err.id} sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1.5 }}>
+                                            <Box sx={{ minWidth: 160 }}>
+                                                <Typography variant="body2" fontWeight="bold">
+                                                    {err.brand} {err.model}
+                                                </Typography>
+                                                <Typography
+                                                    variant="caption"
+                                                    sx={{ textDecoration: 'line-through', color: 'var(--error)' }}
+                                                >
+                                                    {err.invalidCategory}
+                                                </Typography>
+                                            </Box>
+                                            <FormControl size="small" sx={{ minWidth: 200 }}>
+                                                <Select
+                                                    value={categoryOverrides[err.id] || ''}
+                                                    onChange={(e) => handleCategoryOverride(err.id, e.target.value as string)}
+                                                    displayEmpty
+                                                >
+                                                    <MenuItem value="" disabled>
+                                                        Select category
+                                                    </MenuItem>
+                                                    {categories.map((cat) => (
+                                                        <MenuItem key={cat.getId()} value={cat.getName()}>
+                                                            {cat.getName()}
+                                                        </MenuItem>
+                                                    ))}
+                                                </Select>
+                                            </FormControl>
+                                        </Box>
+                                    ))}
+                                </Alert>
+                            )}
+
                             <TextField
                                 type="text"
                                 label="Additional notes"
@@ -210,8 +311,12 @@ const ScheduleDropOff = (props: ScheduleDropOffProps) => {
                                 </FormControl>
                             )}
                             <Box sx={{ marginTop: '2em' }} display={'flex'} gap={2}>
-                                <Button onClick={handleSubmit} variant="contained">
-                                    Send Email
+                                <Button
+                                    onClick={handleSubmit}
+                                    variant="contained"
+                                    disabled={categoryErrors.length > 0 && !allErrorsCorrected}
+                                >
+                                    {allErrorsCorrected ? 'Retry & Send Email' : 'Send Email'}
                                 </Button>
                                 <Button variant="outlined" type="button" onClick={() => setOpenScheduler(false)}>
                                     Cancel

--- a/src/styles/globalStyles.css
+++ b/src/styles/globalStyles.css
@@ -93,8 +93,8 @@
 
 .page--header {
     width: 100%;
-    padding: 1rem 0;
-    margin-top: 2em;
+    padding: 0.5rem 0;
+    margin-top: 0.75em;
 }
 
 /* .page--header > p {


### PR DESCRIPTION
Closes #331, #332

<img width="1280" height="763" alt="Screenshot_2026-05-14_04-05-15" src="https://github.com/user-attachments/assets/f3210690-d8f8-4423-b6f8-df0e428722b0" />


The notifications dashboard was a single scrolling list with all 5 sections shown at once, in the wrong order, with no way to tell how many items are in each section without scrolling through everything. This was apart of Wendy's feedback in the May 12th document.

This PR restructures the Notifications panel into **tabbed navigation** matching the donation lifecycle. Each tab has an inline count badge so the admin can triage at a glance without clicking into each one.

Also includes a fix for `ScheduleDropOff` where donations with unrecognized categories (e.g. "Play Mats" from the old form) would silently crash during approval. Now it validates categories upfront and shows an inline picker to correct them.

## Changes

* Replaced flat notification sections with MUI Tabs in lifecycle order per #332: **Pending Approval → Pending Delivery → Requested → Pending Pickup → Pending Users**
* Orders in Requested tab sorted alphabetically by requestor name (#331)
* Donor group headers on bulk donations showing "Name — N items" with Review button inline
* Cards switched from `raised` to `variant="outlined"`, smaller image placeholders (160px → 100px), tighter border radius (25px → 8px)
* Refresh button moved from its own row into the admin tab bar, right aligned
* Reduced `.page--header` whitespace across all admin tabs (was 2em margin + 1rem padding, felt like a mile)
* Removed hardcoded `marginTop: '4em'` on Inventory that was causing extra gap compared to other tabs
* **ScheduleDropOff**: category validation with override UI, sequential processing with rollback on failure

### Notification tab structure

| Tab              | Status filter         | Grouped by            | Sorted by              |
| :--------------- | :-------------------- | :-------------------- | :--------------------- |
| Pending Approval | `in processing`       | Bulk donation (donor) | Default                |
| Pending Delivery | `pending delivery`    | Bulk donation (donor) | Default                |
| Requested        | orders with items     | Order (requestor)     | Requestor name (alpha) |
| Pending Pickup   | `reserved`            | Bulk donation (donor) | Default                |
| Pending Users    | `isDisabled === true` | N/A                   | Default                |

### Seed script

Added `scripts/seed-emulators.cjs` with data covering all notification states. Previously only "in processing" and "requested" had seed data, so 3 of the 5 tabs were empty during testing.

```
node scripts/seed-emulators.cjs
```

Creates users, categories, orgs, donations in every status, orders, and pending users. All test accounts use password `password`.

### Testing

Checkout, run emulators, seed, login as `admin1@email.com`. Click through each notification tab and verify the counts/content match. Take an action (e.g. Add to Inventory on the Pending Delivery tab) and verify tab state persists without page reload. Check the Donations/Inventory/Users tabs for spacing regression.