### PR TITLE
staging-dev:bugfix: bulk donation approval with invalid categories w/ recategorize

### DIFF
--- a/src/app/accept/[id]/page.tsx
+++ b/src/app/accept/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 //Hoooks
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 //Components
 import ProtectedAdminRoute from '@/components/ProtectedAdminRoute';
 import Loader from '@/components/Loader';
@@ -12,11 +13,13 @@ import ScheduleDropOff from '@/components/ScheduleDropOff';
 //API
 import { addErrorEvent } from '@/api/firebase';
 import { getDonationsByBulkId } from '@/api/firebase-donations';
+import { getAllCategories } from '@/api/firebase-categories';
 import posthog from 'posthog-js';
 //Styles
 import '@/styles/globalStyles.css';
 //types
 import { Donation } from '@/models/donation';
+import { Category } from '@/models/category';
 
 const AcceptDonation = ({ params }: { params: { id: string } }) => {
     const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -25,6 +28,9 @@ const AcceptDonation = ({ params }: { params: { id: string } }) => {
     const [rejected, setRejected] = useState<string[]>([]);
     const [idToDisplay, setIdToDisplay] = useState<string | null>(null);
     const [openSecheduler, setOpenScheduler] = useState<boolean>(false);
+    const [categories, setCategories] = useState<Category[]>([]);
+
+    const router = useRouter();
 
     //disable btton unless all donations are accepted or rejected
     const isDisabled = donations ? accepted.length + rejected.length !== donations.length : false;
@@ -33,7 +39,14 @@ const AcceptDonation = ({ params }: { params: { id: string } }) => {
         setIsLoading(true);
         try {
             const donationsResult = await getDonationsByBulkId(id);
-            setDonations(donationsResult);
+            const pendingDonations = donationsResult.filter((d) => d.status === 'in processing');
+
+            if (pendingDonations.length === 0) {
+                alert('All items in this donation have already been processed.');
+                router.push('/');
+                return;
+            }
+            setDonations(pendingDonations);
         } catch (error) {
             addErrorEvent('Fetch donations by bulk id', error);
         } finally {
@@ -58,8 +71,15 @@ const AcceptDonation = ({ params }: { params: { id: string } }) => {
         }
     };
 
+    const handleCategoryFixed = (donationId: string, newCategory: string) => {
+        setDonations((prev) => prev && prev.map((d) => (d.id === donationId ? Object.assign(Object.create(Object.getPrototypeOf(d)), d, { category: newCategory }) : d)));
+    };
+
     useEffect(() => {
         fetchDonationsByBulkId(params.id);
+        getAllCategories()
+            .then(setCategories)
+            .catch((err) => addErrorEvent('Fetch categories', err));
     }, []);
 
     return (
@@ -101,6 +121,8 @@ const AcceptDonation = ({ params }: { params: { id: string } }) => {
                                         donation={donation}
                                         handleAcceptReject={handleAcceptReject}
                                         setIdToDisplay={setIdToDisplay}
+                                        categories={categories}
+                                        onCategoryFixed={handleCategoryFixed}
                                     />
                                 ))}
                                 <Button type="button" variant="contained" disabled={isDisabled} onClick={() => setOpenScheduler(true)}>

--- a/src/components/AcceptRejectCard.tsx
+++ b/src/components/AcceptRejectCard.tsx
@@ -1,8 +1,24 @@
 'use client';
 
-import { Card, CardActions, CardMedia, CardContent, Typography, Button, ToggleButtonGroup, ToggleButton } from '@mui/material';
+import {
+    Alert,
+    Box,
+    Button,
+    Card,
+    CardActions,
+    CardMedia,
+    CardContent,
+    FormControl,
+    MenuItem,
+    Select,
+    ToggleButtonGroup,
+    ToggleButton,
+    Typography
+} from '@mui/material';
 import ProtectedAdminRoute from './ProtectedAdminRoute';
 import { Donation } from '@/models/donation';
+import { Category } from '@/models/category';
+import { updateDonation } from '@/api/firebase-donations';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
 import '@/styles/globalStyles.css';
@@ -17,16 +33,34 @@ type AcceptRejectCardProps = {
     donation: Donation;
     handleAcceptReject: (value: ButtonStatus, id: string) => void;
     setIdToDisplay: Dispatch<SetStateAction<string | null>>;
+    categories?: Category[];
+    onCategoryFixed?: (donationId: string, newCategory: string) => void;
 };
 
 type ButtonStatus = 'accepted' | 'rejected' | null;
 
 const AcceptRejectCard = (props: AcceptRejectCardProps) => {
-    const { donation, handleAcceptReject, setIdToDisplay } = props;
+    const { donation, handleAcceptReject, setIdToDisplay, categories, onCategoryFixed } = props;
     const [status, setStatus] = useState<ButtonStatus>(null);
+    const [selectedCategory, setSelectedCategory] = useState<string>('');
+    const [isSaving, setIsSaving] = useState(false);
+
+    const validCategoryNames = categories?.map((c) => c.getName()) || [];
+    const hasInvalidCategory = categories && categories.length > 0 && !validCategoryNames.includes(donation.category);
 
     const handleToggle = (event: React.MouseEvent<HTMLElement>, value: ButtonStatus) => {
         setStatus(value);
+    };
+
+    const handleFixCategory = async () => {
+        if (!selectedCategory) return;
+        setIsSaving(true);
+        try {
+            await updateDonation(donation.id, { category: selectedCategory });
+            onCategoryFixed?.(donation.id, selectedCategory);
+        } finally {
+            setIsSaving(false);
+        }
     };
 
     useEffect(() => {
@@ -44,14 +78,43 @@ const AcceptRejectCard = (props: AcceptRejectCardProps) => {
                     </CardContent>
                 </CardActions>
                 <CardActions>
-                    <ToggleButtonGroup value={status} exclusive onChange={handleToggle}>
-                        <ToggleButton value="accepted" aria-label="accept button" color="success">
-                            Accept
-                        </ToggleButton>
-                        <ToggleButton value="rejected" aria-label="reject button" color="error">
-                            Reject
-                        </ToggleButton>
-                    </ToggleButtonGroup>
+                    {hasInvalidCategory ? (
+                        <Alert severity="warning" sx={{ width: '100%' }}>
+                            <Typography variant="body2" fontWeight="bold" gutterBottom>
+                                Unrecognized category: &ldquo;{donation.category}&rdquo;
+                            </Typography>
+                            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', mt: 1 }}>
+                                <FormControl size="small" sx={{ minWidth: 180 }}>
+                                    <Select
+                                        value={selectedCategory}
+                                        onChange={(e) => setSelectedCategory(e.target.value as string)}
+                                        displayEmpty
+                                    >
+                                        <MenuItem value="" disabled>
+                                            Select category
+                                        </MenuItem>
+                                        {categories!.map((cat) => (
+                                            <MenuItem key={cat.getId()} value={cat.getName()}>
+                                                {cat.getName()}
+                                            </MenuItem>
+                                        ))}
+                                    </Select>
+                                </FormControl>
+                                <Button variant="contained" size="small" onClick={handleFixCategory} disabled={!selectedCategory || isSaving}>
+                                    {isSaving ? 'Saving...' : 'Fix'}
+                                </Button>
+                            </Box>
+                        </Alert>
+                    ) : (
+                        <ToggleButtonGroup value={status} exclusive onChange={handleToggle}>
+                            <ToggleButton value="accepted" aria-label="accept button" color="success">
+                                Accept
+                            </ToggleButton>
+                            <ToggleButton value="rejected" aria-label="reject button" color="error">
+                                Reject
+                            </ToggleButton>
+                        </ToggleButtonGroup>
+                    )}
                 </CardActions>
             </Card>
         </ProtectedAdminRoute>

--- a/src/components/DonationDetails.tsx
+++ b/src/components/DonationDetails.tsx
@@ -17,6 +17,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import EditIcon from '@mui/icons-material/Edit';
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
 import AddIcon from '@mui/icons-material/Add';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import DownloadIcon from '@mui/icons-material/Download';
 //Styles
 import '@/styles/globalStyles.css';
@@ -104,6 +105,26 @@ const DonationDetails = (props: DonationDetailsProps) => {
         setIsImageOpen(true);
     };
 
+    const resetToInProcessing = async (): Promise<void> => {
+        setIsLoading(true);
+        try {
+            if (donationDetails) {
+                await updateDonationStatus(donationDetails.id, 'in processing');
+                await updateDonation(donationDetails.id, {
+                    dateAccepted: null,
+                    tagNumber: null
+                });
+                setDialogContent(`'${donationDetails.brand} - ${donationDetails.model}' has been returned to the approval queue.`);
+                setIsDialogOpen(true);
+            }
+        } catch (error) {
+            addErrorEvent('Error resetting donation to in processing', error);
+            throw error;
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
     const handleImageClose = () => setIsImageOpen(false);
 
     const generateProductLifeCycleReport = (donation: Donation) => {
@@ -151,6 +172,11 @@ const DonationDetails = (props: DonationDetailsProps) => {
                             {donationDetails.status === 'unavailable' && (
                                 <Button variant="contained" startIcon={<AddIcon />} color="error" onClick={addToInventory}>
                                     Add to inventory
+                                </Button>
+                            )}
+                            {donationDetails.status !== 'in processing' && donationDetails.status !== 'distributed' && (
+                                <Button variant="outlined" startIcon={<RestartAltIcon />} color="warning" onClick={resetToInProcessing}>
+                                    Return to Approval Queue
                                 </Button>
                             )}
                         </Stack>


### PR DESCRIPTION
The category validation fix in #328 prevents new donations from being submitted with invalid categories, but donations submitted before that fix can still have bad category fields sitting in Firestore. When an admin tries to approve a bulk donation containing one of these items, `getTagNumber()` throws and leaves the bulk in a half processed state. Accepted items get written while the bad one errors out, and on revisit, all items (including already accepted ones) show up again because the review page had no status filter.

This PR fixes the bulk donation approval flow to handle polluted category fields gracefully.

## Changes

* **bugfix**: bulk review page (`/accept/[id]`) now filters items by `status === 'in processing'`, so already accepted/rejected items don't reappear. If all items are processed, redirects back to notifications
* **feature**: inline recategorize UI on `AcceptRejectCard`. If an item has an unrecognized category, the card shows a warning with a dropdown of valid categories and a "Fix" button instead of Accept/Reject. Fixing writes the corrected category to Firestore immediately, then normal Accept/Reject buttons appear
* **feature**: "Return to Approval Queue" button on `DonationDetails` for any non distributed donation. Resets status to `in processing` and clears `dateAccepted`/`tagNumber`. This lets admins recover donations stuck in `pending delivery` from the old partial write bug

### Files Changed

| File                                  | What changed                                                                                     |
| :------------------------------------ | :----------------------------------------------------------------------------------------------- |
| `src/app/accept/[id]/page.tsx`        | Status filter, redirect on empty, categories fetch, passes categories + onCategoryFixed to cards |
| `src/components/AcceptRejectCard.tsx` | Detects invalid category, renders recategorize UI inline, writes fix to Firestore                |
| `src/components/DonationDetails.tsx`  | "Return to Approval Queue" button with status reset                                              |

### Related

* #321, #325, #328, #329
* FIXES: #336 
### Testing

Run the emulator, seed,, login as admin. Ren Ochoa  has an item of  category "Play Mats" which doesn't exist in Categories. Navigate to Notifications > Review Ren Ochoa's bulk donation. Play Mat card should show the recategorize warning. Pick "Toys", click Fix, then proceed through the normal accept/reject flow.

To test the reset button, go to Donations tab, find any donation not in "in processing", click into it, and verify the "Return to Approval Queue" button works.