### PR TITLE
fix(users): edit users without enabling accounts

### DIFF
--- a/src/app/actions/firebase.ts
+++ b/src/app/actions/firebase.ts
@@ -12,6 +12,11 @@ import {
 import { FieldValue } from 'firebase-admin/firestore';
 import { UserRecord } from 'firebase-admin/auth';
 import { AuthUserRecord, NewUserAccountInfo } from '@/types/UserTypes';
+import sendMail from '@/api/nodemailer';
+import adminUserCreated from '@/email-templates/adminUserCreated';
+import adminUserEnabled from '@/email-templates/adminUserEnabled';
+import userEnabled from '@/email-templates/userEnabled';
+import type { IUser } from '@/models/user';
 
 type RoleClaim = 'admin' | 'aid-worker' | 'donor' | 'verified' | 'volunteer';
 
@@ -38,6 +43,27 @@ async function _verifyAdminToken(idToken: string): Promise<void> {
     }
 }
 
+async function sendAdminNotificationEmail(message: ReturnType<typeof adminUserCreated> | ReturnType<typeof adminUserEnabled>, location: string): Promise<void> {
+    try {
+        await sendMail(message);
+    } catch (emailError) {
+        addErrorEvent(location, emailError);
+    }
+}
+
+function serializeFirestoreData<T>(value: T): T {
+    if (value == null) return value;
+    if (typeof value === 'object' && 'toDate' in value && typeof value.toDate === 'function') {
+        return value.toDate().toISOString() as T;
+    }
+    if (Array.isArray(value)) {
+        return value.map((item) => serializeFirestoreData(item)) as T;
+    }
+    if (typeof value === 'object') {
+        return Object.fromEntries(Object.entries(value).map(([key, nestedValue]) => [key, serializeFirestoreData(nestedValue)])) as T;
+    }
+    return value;
+}
 
 export async function addEvent(request: EventRequest): Promise<void> {
     try {
@@ -66,6 +92,20 @@ export async function getOrganizationNames(): Promise<{ [key: string]: string }>
     } catch (error) {
         addErrorEvent('getOrganizationNames', error);
         throw new Error('Unable to fetch organization names');
+    }
+}
+
+export async function getUserDetails(request: { idToken: string; userId: string }): Promise<IUser> {
+    try {
+        await _verifyAdminToken(request.idToken);
+        const userSnapshot = await db.collection(USERS_COLLECTION).doc(request.userId).get();
+        if (!userSnapshot.exists) {
+            throw new Error('User not found');
+        }
+        return serializeFirestoreData({ uid: userSnapshot.id, ...userSnapshot.data() } as IUser);
+    } catch (error) {
+        addErrorEvent('getUserDetails', error);
+        throw error;
     }
 }
 
@@ -128,6 +168,8 @@ export async function createUser(request: NewUserAccountInfo): Promise<UserRecor
         throw new Error('An error occurred while trying to create a new user.');
     }
 
+    await sendAdminNotificationEmail(adminUserCreated(userRecord.uid, request), 'createUser admin notification email');
+
     return JSON.parse(JSON.stringify(userRecord));
 }
 
@@ -160,6 +202,8 @@ export async function enableUser(request: { idToken: string; userId: string }): 
             customClaims: { 'aid-worker': true },
             modifiedAt: FieldValue.serverTimestamp()
         });
+        await sendAdminNotificationEmail(adminUserEnabled({ uid: user.uid, email: user.email, displayName: user.displayName }), 'enableUser admin notification email');
+        await sendMail(userEnabled(user.email ?? '', user.displayName ?? ''));
     } catch (error) {
         addErrorEvent('enableUser', error);
         throw error;

--- a/src/components/EditUser.tsx
+++ b/src/components/EditUser.tsx
@@ -4,32 +4,29 @@
 import { useState, useEffect, Dispatch, SetStateAction } from 'react';
 //API
 import { addErrorEvent, getAuthIdToken } from '@/api/firebase';
-import { getOrganizationNames, isEmailInUse as checkEmailInUse, setCustomClaims, updateAuthUser, enableUser } from '@/app/actions/firebase';
-import sendMail from '@/api/nodemailer';
+import { getOrganizationNames, isEmailInUse as checkEmailInUse, setCustomClaims, updateAuthUser } from '@/app/actions/firebase';
 //Components
 import { Paper, Box, FormControl, Autocomplete, TextField, Button, FormLabel, RadioGroup, FormControlLabel, Radio, Typography } from '@mui/material';
 import Loader from '@/components/Loader';
 import CustomDialog from './CustomDialog';
 import ProtectedAdminRoute from './ProtectedAdminRoute';
-//Constants
-import userEnabled from '@/email-templates/userEnabled';
 //Styles
 import '@/styles/globalStyles.css';
 //Types
 import { PatternFormat, OnValueChange } from 'react-number-format';
 
-import { UserCollection } from '@/models/user';
+import { IUser } from '@/models/user';
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type EditUserProps = {
-    userDetails: UserCollection;
+    userDetails: IUser;
     setIsEditMode: Dispatch<SetStateAction<boolean>>;
     setUserDetailsUpdated?: Dispatch<SetStateAction<boolean>>;
 };
 
 const EditUser = (props: EditUserProps) => {
-    const { uid, email, displayName, customClaims, phoneNumber, notes, organization, isDisabled, title } = props.userDetails;
+    const { uid, email, displayName, customClaims, phoneNumber, organization, isDisabled, title } = props.userDetails;
     const { setIsEditMode, setUserDetailsUpdated } = props;
 
     let initialRole = '';
@@ -87,8 +84,10 @@ const EditUser = (props: EditUserProps) => {
     };
 
     const handleEmailInput = async (event: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
-        setNewEmail(event.target.value);
-        validateEmail(newEmail);
+        const nextEmail = event.target.value;
+        setNewEmail(nextEmail);
+        validateEmail(nextEmail);
+        if (nextEmail === email) setIsEmailInUse(false);
     };
 
     const handleBlur = async (): Promise<void> => {
@@ -112,15 +111,6 @@ const EditUser = (props: EditUserProps) => {
         event.preventDefault();
         setIsLoading(true);
         try {
-            if (isDisabled) {
-                try {
-                    await enableUser({ idToken: await getAuthIdToken(), userId: uid });
-                    const emailMsg = userEnabled(email, displayName);
-                    await sendMail(emailMsg);
-                } catch (error) {
-                    addErrorEvent('Error enable user', error);
-                }
-            }
             if (role !== initialRole) {
                 try {
                     const claims: Partial<Record<string, boolean>> = { [role]: true };
@@ -228,6 +218,11 @@ const EditUser = (props: EditUserProps) => {
                             displayType="input"
                             customInput={TextField}
                         />
+                        {isDisabled && (
+                            <Typography variant="body2" color="text.secondary">
+                                Saving these changes will not enable this user account.
+                            </Typography>
+                        )}
                         <FormControl disabled={!customClaims}>
                             <FormLabel id="role-radio-buttons-label">Role:</FormLabel>
                             <RadioGroup aria-labelledby="role-radio-buttons-label" name="role-radio-buttons-group" value={role} onChange={handleRadioChange}>
@@ -236,15 +231,9 @@ const EditUser = (props: EditUserProps) => {
                             </RadioGroup>
                         </FormControl>
                         <Box display={'flex'} gap={2}>
-                            {!initialOrg ? (
-                                <Button variant="contained" type="submit" disabled={!selectedOrg}>
-                                    Enable User
-                                </Button>
-                            ) : (
-                                <Button variant="contained" type="submit">
-                                    Update User
-                                </Button>
-                            )}
+                            <Button variant="contained" type="submit" disabled={isEmailInUse || isInvalidEmail}>
+                                Update User
+                            </Button>
 
                             <Button variant="outlined" type="button" onClick={() => setIsEditMode(false)}>
                                 Cancel

--- a/src/components/UserDetails.tsx
+++ b/src/components/UserDetails.tsx
@@ -5,36 +5,40 @@ import { useEffect, useState, Dispatch, SetStateAction } from 'react';
 //Components
 import Loader from '@/components/Loader';
 import EditUser from '@/components/EditUser';
-import { ListItem, Typography, Button, IconButton } from '@mui/material';
+import { ListItem, Typography, Button, IconButton, Box } from '@mui/material';
 import ProtectedAdminRoute from '@/components/ProtectedAdminRoute';
 import CustomDialog from '@/components/CustomDialog';
 //APIs
-import { addErrorEvent } from '@/api/firebase';
-import { getDbUser } from '@/api/firebase-users';
+import { addErrorEvent, getAuthIdToken } from '@/api/firebase';
+import { enableUser, getUserDetails } from '@/app/actions/firebase';
 //icons
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import EditIcon from '@mui/icons-material/Edit';
 //styles
 import '@/styles/globalStyles.css';
 //Types
-import { UserCollection } from '@/models/user';
+import { IUser } from '@/models/user';
 
 type UserDetailsProps = {
     id: string;
-    user?: UserCollection;
+    user?: IUser;
     setIdToDisplay?: Dispatch<SetStateAction<string | null>>;
     setUsersUpdated?: Dispatch<SetStateAction<boolean>>;
+    onUsersChanged?: () => void;
 };
 
 export default function UserDetails(props: UserDetailsProps) {
-    const { id, setIdToDisplay, setUsersUpdated, user } = props;
+    const { id, setIdToDisplay, setUsersUpdated, onUsersChanged, user } = props;
     const [isLoading, setIsLoading] = useState<boolean>(true);
-    const [userDetails, setUserDetails] = useState<UserCollection | null>(null);
+    const [userDetails, setUserDetails] = useState<IUser | null>(null);
     const [isEditMode, setIsEditMode] = useState<boolean>(false);
     const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
+    const [dialogTitle, setDialogTitle] = useState<string>('User updated');
+    const [dialogContent, setDialogContent] = useState<string>('');
     const [userDetailsUpdated, setUserDetailsUpdated] = useState<boolean>(false);
 
     const handleClose = () => {
+        if (onUsersChanged) onUsersChanged();
         if (setUsersUpdated) setUsersUpdated(true);
         //Re-fetch user to show updated details
         if (userDetails) {
@@ -46,7 +50,7 @@ export default function UserDetails(props: UserDetailsProps) {
     async function fetchUserDetails(id: string): Promise<void> {
         setIsLoading(true);
         try {
-            const userDetailsResult: UserCollection = await getDbUser(id);
+            const userDetailsResult = await getUserDetails({ idToken: await getAuthIdToken(), userId: id });
             setUserDetails(userDetailsResult);
         } catch (error) {
             addErrorEvent('Fetch user details', error);
@@ -55,6 +59,26 @@ export default function UserDetails(props: UserDetailsProps) {
         }
     }
 
+    const handleEnableUser = async (): Promise<void> => {
+        if (!userDetails) return;
+
+        setIsLoading(true);
+        try {
+            await enableUser({ idToken: await getAuthIdToken(), userId: userDetails.uid });
+            setDialogTitle('User enabled');
+            setDialogContent(`User ${userDetails.displayName} has been enabled.`);
+            setUserDetailsUpdated(true);
+            setIsDialogOpen(true);
+        } catch (error) {
+            addErrorEvent('Enable user from user details', error);
+            setDialogTitle('Unable to enable user');
+            setDialogContent(`User ${userDetails.displayName} could not be enabled. Please try again.`);
+            setIsDialogOpen(true);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
     //Re-fetch user if user has been updated.
     useEffect(() => {
         if (!user || userDetailsUpdated) {
@@ -62,7 +86,7 @@ export default function UserDetails(props: UserDetailsProps) {
         } else {
             setUserDetails(user);
         }
-    }, [userDetailsUpdated]);
+    }, [id, user, userDetailsUpdated]);
 
     return (
         <ProtectedAdminRoute>
@@ -117,15 +141,22 @@ export default function UserDetails(props: UserDetailsProps) {
                                 </ul>
                             </>
                         )}
-                        <Button variant="contained" type="button" onClick={() => setIsEditMode(true)} sx={{ marginTop: '2em' }} startIcon={<EditIcon />}>
-                            Edit User
-                        </Button>
+                        <Box display="flex" gap={2} flexWrap="wrap" sx={{ marginTop: '2em' }}>
+                            <Button variant="contained" type="button" onClick={() => setIsEditMode(true)} startIcon={<EditIcon />}>
+                                Edit User
+                            </Button>
+                            {userDetails.isDisabled && (
+                                <Button variant="outlined" type="button" onClick={handleEnableUser}>
+                                    Enable User
+                                </Button>
+                            )}
+                        </Box>
                     </div>
                 )}
                 {!isLoading && userDetails && isEditMode && (
                     <EditUser userDetails={userDetails} setIsEditMode={setIsEditMode} setUserDetailsUpdated={setUserDetailsUpdated} />
                 )}
-                <CustomDialog isOpen={isDialogOpen} onClose={handleClose} title="User enabled" content={`User ${userDetails?.displayName} has been enabled.`} />
+                <CustomDialog isOpen={isDialogOpen} onClose={handleClose} title={dialogTitle} content={dialogContent} />
             </div>
         </ProtectedAdminRoute>
     );

--- a/src/data/adminNotificationEmail.ts
+++ b/src/data/adminNotificationEmail.ts
@@ -1,0 +1,5 @@
+import 'server-only';
+
+import { emailSender } from '@/data/emailSender';
+
+export const adminNotificationEmail: string = process.env.ADMIN_NOTIFICATION_EMAIL || process.env.EMAIL_SENDER || process.env.SMTP_USER || emailSender;

--- a/src/email-templates/adminUserCreated.ts
+++ b/src/email-templates/adminUserCreated.ts
@@ -1,0 +1,25 @@
+import 'server-only';
+
+import { adminNotificationEmail } from '@/data/adminNotificationEmail';
+import { sanitize } from '@/utils/utils';
+import { NewUserAccountInfo } from '@/types/UserTypes';
+
+export default function adminUserCreated(userId: string, accountInfo: NewUserAccountInfo) {
+    const organization = accountInfo.organization?.name ?? accountInfo.notes.find((note) => note.startsWith('User provided organization:')) ?? 'Not provided';
+    const title = accountInfo.title || 'Not provided';
+
+    return {
+        to: adminNotificationEmail,
+        from: adminNotificationEmail,
+        subject: 'Baby Product Exchange account created',
+        html: `
+            <p>A new Baby Product Exchange account has been created and is awaiting review.</p>
+            <p><b>Name:</b> ${sanitize(accountInfo.displayName)}</p>
+            <p><b>Email:</b> ${sanitize(accountInfo.email)}</p>
+            <p><b>Phone:</b> ${sanitize(accountInfo.phoneNumber)}</p>
+            <p><b>Organization:</b> ${sanitize(organization)}</p>
+            <p><b>Title:</b> ${sanitize(title)}</p>
+            <p><b>User ID:</b> ${sanitize(userId)}</p>
+        `
+    };
+}

--- a/src/email-templates/adminUserEnabled.ts
+++ b/src/email-templates/adminUserEnabled.ts
@@ -1,0 +1,24 @@
+import 'server-only';
+
+import { adminNotificationEmail } from '@/data/adminNotificationEmail';
+import { sanitize } from '@/utils/utils';
+
+type EnabledUserNotification = {
+    email?: string;
+    displayName?: string;
+    uid: string;
+};
+
+export default function adminUserEnabled(user: EnabledUserNotification) {
+    return {
+        to: adminNotificationEmail,
+        from: adminNotificationEmail,
+        subject: 'Baby Product Exchange account enabled',
+        html: `
+            <p>A Baby Product Exchange account has been enabled.</p>
+            <p><b>Name:</b> ${sanitize(user.displayName ?? 'Not provided')}</p>
+            <p><b>Email:</b> ${sanitize(user.email ?? 'Not provided')}</p>
+            <p><b>User ID:</b> ${sanitize(user.uid)}</p>
+        `
+    };
+}


### PR DESCRIPTION
# User Enablement And Details

Branch: `staging/bugfix/user-enablement-details`  
Worktree: `/Users/nathan/node/bpe-split-user-enablement`  
Base: `upstream/staging/release-may-dev` at `690a7ca`  
Tip: `1a81ab3`  
Type: Bug fix  

## Summary

This branch separates editing user details from enabling user accounts. It also moves pending-user details through an admin server action so newly created or disabled users can be viewed reliably, and adds administrator email templates for user-created and user-enabled notifications.

## Change Table

| Area | Files | Change |
| --- | --- | --- |
| Server actions | `src/app/actions/firebase.ts` | Adds admin-protected user detail loading and administrator notification email handling. |
| User edit form | `src/components/EditUser.tsx` | Removes implicit account enablement from profile edits and clarifies that save does not enable disabled users. |
| User details | `src/components/UserDetails.tsx` | Adds explicit Enable User button and loads pending user details through server action. |
| Email data | `src/data/adminNotificationEmail.ts` | Centralizes admin notification sender/recipient mapping. |
| Email templates | `src/email-templates/adminUserCreated.ts`, `src/email-templates/adminUserEnabled.ts` | Adds account-created and account-enabled administrator templates. |

## Detailed Review

### Editing no longer enables accounts

- `EditUser` no longer calls `enableUser` while saving profile edits.
- The form button text is consistently "Update User" rather than changing to "Enable User".
- Disabled users see copy explaining that saving changes will not enable the account.

### Explicit enablement

- `UserDetails` now shows an Enable User button only when the account is disabled.
- Enablement calls the admin server action and then refreshes detail state.
- Success and failure states use the dialog title/content instead of hard-coded enablement copy.

### Pending user details

- User detail loading now calls `getUserDetails` with an admin ID token.
- This avoids client Firestore access paths that can fail for disabled/newly-created users.
- Firestore timestamp-like values are serialized before returning to the client.

### Administrator email notifications

- User-created and user-enabled administrator notifications use dedicated templates.
- The server action awaits and logs administrator email failures intentionally.
- User enablement still sends the existing enabled-user email to the user.

### Compatibility note

- During split validation, `UserDetails` was adjusted to accept both the older `setUsersUpdated` prop and the newer `onUsersChanged` callback.
- This keeps the bugfix branch buildable against the release-dev base while still aligning with the later Dashboard callback refactor.

## Reviewer Focus

| Focus | What to check |
| --- | --- |
| Account status safety | Confirm editing a disabled user does not enable the account. |
| Explicit enablement | Confirm only the Enable User button changes disabled state. |
| Security boundary | Confirm user details use admin-protected server action access. |
| Email behavior | Confirm created/enabled administrator email templates use expected sender/recipient mapping. |
| State refresh | Confirm user details refresh after edits and enablement. |