### PR TITLE
feature(order-flow): reject item flow

### DIFF
--- a/src/api/firebase-donations.ts
+++ b/src/api/firebase-donations.ts
@@ -39,6 +39,11 @@ export const DONATIONS_COLLECTION = 'Donations';
 export const BULK_DONATIONS_COLLECTION = 'BulkDonations';
 export const ORDERS_COLLECTION = 'Orders';
 
+export type OrderItemRejectionResolution =
+    | { action: 'available' }
+    | { action: 'unavailable' }
+    | { action: 'requested'; requestor: { id: string; name: string; email: string } };
+
 const donationConverter = {
     toFirestore(donation: Donation): DocumentData {
         const donationData: IDonation = {
@@ -580,8 +585,12 @@ export async function closeOrder(id: string): Promise<void> {
     }
 }
 
-//Removes rejected donation from order, add to rejectedItems array, and changes status to 'unavailable'.
-export async function removeDonationFromOrder(orderId: string, donation: Donation): Promise<void> {
+//Removes rejected donation from order, adds it to rejectedItems, and applies the selected next step.
+export async function removeDonationFromOrder(
+    orderId: string,
+    donation: Donation,
+    resolution: OrderItemRejectionResolution = { action: 'unavailable' }
+): Promise<void> {
     try {
         const batch = writeBatch(db);
         const orderRef = doc(db, `${ORDERS_COLLECTION}/${orderId}`);
@@ -591,11 +600,38 @@ export async function removeDonationFromOrder(orderId: string, donation: Donatio
             rejectedItems: arrayUnion(donationRef),
             modifiedAt: serverTimestamp()
         });
-        batch.update(donationRef, {
-            status: 'unavailable',
-            requestor: null,
-            modifiedAt: serverTimestamp()
-        });
+
+        if (resolution.action === 'available') {
+            batch.update(donationRef, {
+                status: 'available',
+                requestor: null,
+                dateRequested: null,
+                modifiedAt: serverTimestamp()
+            });
+        } else if (resolution.action === 'requested') {
+            const reassignedOrderRef = doc(collection(db, ORDERS_COLLECTION));
+            batch.set(reassignedOrderRef, {
+                status: 'open',
+                requestor: resolution.requestor,
+                items: [donationRef],
+                rejectedItems: [],
+                createdAt: serverTimestamp(),
+                modifiedAt: serverTimestamp()
+            });
+            batch.update(donationRef, {
+                status: 'requested',
+                requestor: resolution.requestor,
+                dateRequested: serverTimestamp(),
+                modifiedAt: serverTimestamp()
+            });
+        } else {
+            batch.update(donationRef, {
+                status: 'unavailable',
+                requestor: null,
+                modifiedAt: serverTimestamp()
+            });
+        }
+
         await batch.commit();
 
         const updatedOrder = await getDoc(orderRef);
@@ -605,6 +641,7 @@ export async function removeDonationFromOrder(orderId: string, donation: Donatio
         }
     } catch (error) {
         addErrorEvent('Error removing donation from order', error);
+        throw error;
     }
 }
 

--- a/src/api/firebase-donations.ts
+++ b/src/api/firebase-donations.ts
@@ -13,6 +13,7 @@ import {
     getDocs,
     query,
     or,
+    runTransaction,
     serverTimestamp,
     updateDoc,
     where,
@@ -592,53 +593,83 @@ export async function removeDonationFromOrder(
     resolution: OrderItemRejectionResolution = { action: 'unavailable' }
 ): Promise<void> {
     try {
-        const batch = writeBatch(db);
         const orderRef = doc(db, `${ORDERS_COLLECTION}/${orderId}`);
         const donationRef = doc(db, `${DONATIONS_COLLECTION}/${donation.id}`).withConverter(donationConverter);
-        batch.update(orderRef, {
-            items: arrayRemove(donationRef),
-            rejectedItems: arrayUnion(donationRef),
-            modifiedAt: serverTimestamp()
+        const reassignedOrderRef = resolution.action === 'requested' ? doc(collection(db, ORDERS_COLLECTION)) : null;
+
+        await runTransaction(db, async (transaction) => {
+            const orderSnapshot = await transaction.get(orderRef);
+            if (!orderSnapshot.exists()) {
+                throw new Error('Order not found');
+            }
+
+            const donationSnapshot = await transaction.get(donationRef);
+            if (!donationSnapshot.exists()) {
+                throw new Error('Donation not found');
+            }
+
+            const orderData = orderSnapshot.data();
+            if (orderData.status !== 'open') {
+                throw new Error('Order is no longer open');
+            }
+
+            const donationData = donationSnapshot.data();
+            if (donationData.status !== 'requested') {
+                throw new Error('Donation is no longer requested');
+            }
+
+            if (resolution.action === 'requested' && resolution.requestor.id === orderData.requestor?.id) {
+                throw new Error('Donation is already requested by this user');
+            }
+
+            const orderItems = (orderData.items ?? []) as { id: string; path?: string }[];
+            const matchingOrderItem = orderItems.find((itemRef) => itemRef.id === donation.id || itemRef.path === donationRef.path);
+            if (!matchingOrderItem) {
+                throw new Error('Donation is no longer in this order');
+            }
+
+            const remainingItemCount = orderItems.filter((itemRef) => itemRef.id !== donation.id && itemRef.path !== donationRef.path).length;
+            transaction.update(orderRef, {
+                items: arrayRemove(donationRef),
+                rejectedItems: arrayUnion(donationRef),
+                status: remainingItemCount === 0 ? 'closed' : orderData.status,
+                modifiedAt: serverTimestamp()
+            });
+
+            if (resolution.action === 'available') {
+                transaction.update(donationRef, {
+                    status: 'available',
+                    requestor: null,
+                    dateRequested: null,
+                    modifiedAt: serverTimestamp()
+                });
+            } else if (resolution.action === 'requested') {
+                if (!reassignedOrderRef) {
+                    throw new Error('Unable to create reassigned order');
+                }
+
+                transaction.set(reassignedOrderRef, {
+                    status: 'open',
+                    requestor: resolution.requestor,
+                    items: [donationRef],
+                    rejectedItems: [],
+                    createdAt: serverTimestamp(),
+                    modifiedAt: serverTimestamp()
+                });
+                transaction.update(donationRef, {
+                    status: 'requested',
+                    requestor: resolution.requestor,
+                    dateRequested: serverTimestamp(),
+                    modifiedAt: serverTimestamp()
+                });
+            } else {
+                transaction.update(donationRef, {
+                    status: 'unavailable',
+                    requestor: null,
+                    modifiedAt: serverTimestamp()
+                });
+            }
         });
-
-        if (resolution.action === 'available') {
-            batch.update(donationRef, {
-                status: 'available',
-                requestor: null,
-                dateRequested: null,
-                modifiedAt: serverTimestamp()
-            });
-        } else if (resolution.action === 'requested') {
-            const reassignedOrderRef = doc(collection(db, ORDERS_COLLECTION));
-            batch.set(reassignedOrderRef, {
-                status: 'open',
-                requestor: resolution.requestor,
-                items: [donationRef],
-                rejectedItems: [],
-                createdAt: serverTimestamp(),
-                modifiedAt: serverTimestamp()
-            });
-            batch.update(donationRef, {
-                status: 'requested',
-                requestor: resolution.requestor,
-                dateRequested: serverTimestamp(),
-                modifiedAt: serverTimestamp()
-            });
-        } else {
-            batch.update(donationRef, {
-                status: 'unavailable',
-                requestor: null,
-                modifiedAt: serverTimestamp()
-            });
-        }
-
-        await batch.commit();
-
-        const updatedOrder = await getDoc(orderRef);
-        const orderData = updatedOrder.data();
-        if (orderData && orderData.items.length === 0 && orderData.rejectedItems?.length > 0) {
-            await closeOrder(orderId);
-        }
     } catch (error) {
         addErrorEvent('Error removing donation from order', error);
         throw error;

--- a/src/api/firebase-donations.ts
+++ b/src/api/firebase-donations.ts
@@ -452,8 +452,9 @@ export async function adminAreDonationsAvailable(ids: string[]): Promise<string[
         return unavailableDonations;
     } catch (error) {
         addErrorEvent('Admin are donations available', error);
+        throw error;
     }
-    return Promise.reject();
+    return [];
 }
 
 export async function adminRequestInventoryItems(inventoryItemIds: string[], user: { id: string; name: string; email: string }): Promise<Order> {

--- a/src/components/DonationCardMed.tsx
+++ b/src/components/DonationCardMed.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 //Hooks
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
 //Components
 import {
+    Alert,
+    Autocomplete,
+    Box,
     Button,
     Card,
     CardActions,
@@ -14,33 +17,121 @@ import {
     DialogContent,
     DialogContentText,
     DialogTitle,
+    TextField,
     Typography
 } from '@mui/material';
 import ProtectedAdminRoute from './ProtectedAdminRoute';
 //Icons
+import Inventory2Icon from '@mui/icons-material/Inventory2';
+import PersonAddAlt1Icon from '@mui/icons-material/PersonAddAlt1';
 import RemoveShoppingCartIcon from '@mui/icons-material/RemoveShoppingCart';
+import ReportProblemIcon from '@mui/icons-material/ReportProblem';
+//Api
+import { addErrorEvent } from '@/api/firebase';
+import { getAllActiveDbUsers } from '@/api/firebase-users';
 //Styles
 import '@/styles/globalStyles.css';
 //types
 import { Donation } from '@/models/donation';
+import { IUser } from '@/models/user';
+import type { OrderItemRejectionResolution } from '@/api/firebase-donations';
 
 type DonationCardMedProps = {
     orderId?: string;
     donation: Donation;
     setIdToDisplay: Dispatch<SetStateAction<string | null>>;
-    handleRemoveFromOrder?: (orderId: string, donation: Donation) => Promise<void>;
+    handleRemoveFromOrder?: (orderId: string, donation: Donation, resolution: OrderItemRejectionResolution) => Promise<void>;
 };
+
+type RejectionAction = OrderItemRejectionResolution['action'];
+
+const rejectionOptions: {
+    action: RejectionAction;
+    label: string;
+    helper: string;
+    icon: JSX.Element;
+    color: 'success' | 'primary' | 'error';
+}[] = [
+    {
+        action: 'available',
+        label: 'Return to inventory',
+        helper: 'Status: available',
+        icon: <Inventory2Icon />,
+        color: 'success'
+    },
+    {
+        action: 'requested',
+        label: 'Reserve for a different user',
+        helper: 'Status: requested',
+        icon: <PersonAddAlt1Icon />,
+        color: 'primary'
+    },
+    {
+        action: 'unavailable',
+        label: 'Mark as unavailable',
+        helper: 'Status: unavailable',
+        icon: <ReportProblemIcon />,
+        color: 'error'
+    }
+];
 
 const DonationCardMed = (props: DonationCardMedProps) => {
     const { orderId, donation, setIdToDisplay, handleRemoveFromOrder } = props;
     const [showRemoveDialog, setShowRemoveDialog] = useState<boolean>(false);
-    const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
+    const [rejectionAction, setRejectionAction] = useState<RejectionAction>('available');
+    const [activeUsers, setActiveUsers] = useState<IUser[]>([]);
+    const [selectedUser, setSelectedUser] = useState<IUser | null>(null);
+    const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+    const [isLoadingUsers, setIsLoadingUsers] = useState<boolean>(false);
+    const [hasLoadedUsers, setHasLoadedUsers] = useState<boolean>(false);
+
+    const availableUsers = useMemo(() => activeUsers.filter((user) => user.uid !== donation.requestor?.id), [activeUsers, donation.requestor?.id]);
 
     const handleRemove = async (id: string, donation: Donation) => {
-        if (handleRemoveFromOrder) {
-            await handleRemoveFromOrder(id, donation);
+        if (!handleRemoveFromOrder) return;
+
+        let resolution: OrderItemRejectionResolution;
+        if (rejectionAction === 'requested') {
+            if (!selectedUser) return;
+            resolution = {
+                action: 'requested',
+                requestor: {
+                    id: selectedUser.uid,
+                    name: selectedUser.displayName,
+                    email: selectedUser.email
+                }
+            };
+        } else {
+            resolution = { action: rejectionAction };
+        }
+
+        setIsSubmitting(true);
+        try {
+            await handleRemoveFromOrder(id, donation, resolution);
+            setShowRemoveDialog(false);
+        } finally {
+            setIsSubmitting(false);
         }
     };
+
+    useEffect(() => {
+        if (!showRemoveDialog || hasLoadedUsers || isLoadingUsers) return;
+
+        const fetchActiveUsers = async () => {
+            setIsLoadingUsers(true);
+            try {
+                const users = await getAllActiveDbUsers();
+                setActiveUsers(users);
+            } catch (error) {
+                addErrorEvent('Fetch users for rejected item reassignment', error);
+            } finally {
+                setHasLoadedUsers(true);
+                setIsLoadingUsers(false);
+            }
+        };
+
+        fetchActiveUsers();
+    }, [hasLoadedUsers, isLoadingUsers, showRemoveDialog]);
 
     return (
         <ProtectedAdminRoute>
@@ -58,21 +149,80 @@ const DonationCardMed = (props: DonationCardMedProps) => {
                 {handleRemoveFromOrder && orderId && (
                     <CardActions>
                         <Button variant="contained" startIcon={<RemoveShoppingCartIcon />} color="error" onClick={() => setShowRemoveDialog(true)}>
-                            Remove
+                            Reject
                         </Button>
                     </CardActions>
                 )}
             </Card>
             {handleRemoveFromOrder && orderId && (
-                <Dialog open={showRemoveDialog} aria-labelledby="dialog-title" aria-describedby="dialog-description">
-                    <DialogTitle id="dialog-title">Remove Donation?</DialogTitle>
+                <Dialog
+                    open={showRemoveDialog}
+                    onClose={() => setShowRemoveDialog(false)}
+                    aria-labelledby="dialog-title"
+                    aria-describedby="dialog-description"
+                    fullWidth
+                    maxWidth="sm"
+                >
+                    <DialogTitle id="dialog-title">Reject Item</DialogTitle>
                     <DialogContent>
-                        <DialogContentText>
-                            This will remove {donation.model + ' ' + donation.brand} from this order and change its status to unavailable. Are you sure?
+                        <DialogContentText id="dialog-description" sx={{ mb: 2 }}>
+                            Choose what should happen to {donation.brand} - {donation.model}.
                         </DialogContentText>
+                        <Alert
+                            severity="info"
+                            sx={{
+                                width: '100%',
+                                border: '1px solid',
+                                borderColor: 'info.light',
+                                backgroundColor: 'rgba(2, 136, 209, 0.08)'
+                            }}
+                        >
+                            <Typography variant="body2" fontWeight="bold" gutterBottom>
+                                Rejection reason
+                            </Typography>
+                            <Box sx={{ display: 'grid', gap: 1, mt: 1 }}>
+                                {rejectionOptions.map((option) => (
+                                    <Button
+                                        key={option.action}
+                                        variant={rejectionAction === option.action ? 'contained' : 'outlined'}
+                                        color={option.color}
+                                        startIcon={option.icon}
+                                        onClick={() => {
+                                            setRejectionAction(option.action);
+                                            if (option.action !== 'requested') setSelectedUser(null);
+                                        }}
+                                        sx={{ justifyContent: 'flex-start', textAlign: 'left' }}
+                                    >
+                                        <Box>
+                                            <Typography variant="body2" fontWeight="bold">
+                                                {option.label}
+                                            </Typography>
+                                            <Typography variant="caption">{option.helper}</Typography>
+                                        </Box>
+                                    </Button>
+                                ))}
+                            </Box>
+                            {rejectionAction === 'requested' && (
+                                <Autocomplete
+                                    sx={{ mt: 2, backgroundColor: 'background.paper' }}
+                                    value={selectedUser}
+                                    loading={isLoadingUsers}
+                                    onChange={(_event: any, newValue: IUser | null) => setSelectedUser(newValue)}
+                                    id={`reassign-requestor-${donation.id}`}
+                                    options={availableUsers}
+                                    getOptionLabel={(user) => `${user.displayName} (${user.email})`}
+                                    isOptionEqualToValue={(option, value) => option.uid === value.uid}
+                                    renderInput={(params) => <TextField {...params} label="New requestor" />}
+                                />
+                            )}
+                        </Alert>
                         <DialogActions>
-                            <Button variant="contained" onClick={() => handleRemove(orderId, donation)}>
-                                Confirm
+                            <Button
+                                variant="contained"
+                                onClick={() => handleRemove(orderId, donation)}
+                                disabled={isSubmitting || (rejectionAction === 'requested' && !selectedUser)}
+                            >
+                                {isSubmitting ? 'Saving...' : 'Confirm'}
                             </Button>
                             <Button variant="outlined" onClick={() => setShowRemoveDialog(false)}>
                                 Cancel

--- a/src/components/DonationCardMed.tsx
+++ b/src/components/DonationCardMed.tsx
@@ -4,7 +4,6 @@
 import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
 //Components
 import {
-    Alert,
     Autocomplete,
     Box,
     Button,
@@ -25,7 +24,7 @@ import ProtectedAdminRoute from './ProtectedAdminRoute';
 import Inventory2Icon from '@mui/icons-material/Inventory2';
 import PersonAddAlt1Icon from '@mui/icons-material/PersonAddAlt1';
 import RemoveShoppingCartIcon from '@mui/icons-material/RemoveShoppingCart';
-import ReportProblemIcon from '@mui/icons-material/ReportProblem';
+import BlockIcon from '@mui/icons-material/Block';
 //Api
 import { addErrorEvent } from '@/api/firebase';
 import { getAllActiveDbUsers } from '@/api/firebase-users';
@@ -48,30 +47,26 @@ type RejectionAction = OrderItemRejectionResolution['action'];
 const rejectionOptions: {
     action: RejectionAction;
     label: string;
-    helper: string;
+    description: string;
     icon: JSX.Element;
-    color: 'success' | 'primary' | 'error';
 }[] = [
     {
         action: 'available',
         label: 'Return to inventory',
-        helper: 'Status: available',
-        icon: <Inventory2Icon />,
-        color: 'success'
+        description: 'Item becomes available for other requests',
+        icon: <Inventory2Icon fontSize="small" />
     },
     {
         action: 'requested',
-        label: 'Reserve for a different user',
-        helper: 'Status: requested',
-        icon: <PersonAddAlt1Icon />,
-        color: 'primary'
+        label: 'Reserve for someone else',
+        description: 'Reassign this item to a different user',
+        icon: <PersonAddAlt1Icon fontSize="small" />
     },
     {
         action: 'unavailable',
         label: 'Mark as unavailable',
-        helper: 'Status: unavailable',
-        icon: <ReportProblemIcon />,
-        color: 'error'
+        description: 'Remove item from circulation',
+        icon: <BlockIcon fontSize="small" />
     }
 ];
 
@@ -164,71 +159,83 @@ const DonationCardMed = (props: DonationCardMedProps) => {
                     maxWidth="sm"
                 >
                     <DialogTitle id="dialog-title">Reject Item</DialogTitle>
-                    <DialogContent>
-                        <DialogContentText id="dialog-description" sx={{ mb: 2 }}>
-                            Choose what should happen to {donation.brand} - {donation.model}.
+                    <DialogContent sx={{ pb: 1, overflowX: 'hidden' }}>
+                        <DialogContentText id="dialog-description" sx={{ mb: 2.5 }}>
+                            What should happen to <strong>{donation.brand} &ndash; {donation.model}</strong>?
                         </DialogContentText>
-                        <Alert
-                            severity="info"
-                            sx={{
-                                width: '100%',
-                                border: '1px solid',
-                                borderColor: 'info.light',
-                                backgroundColor: 'rgba(2, 136, 209, 0.08)'
-                            }}
-                        >
-                            <Typography variant="body2" fontWeight="bold" gutterBottom>
-                                Rejection reason
-                            </Typography>
-                            <Box sx={{ display: 'grid', gap: 1, mt: 1 }}>
-                                {rejectionOptions.map((option) => (
-                                    <Button
+                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                            {rejectionOptions.map((option) => {
+                                const selected = rejectionAction === option.action;
+                                return (
+                                    <Box
                                         key={option.action}
-                                        variant={rejectionAction === option.action ? 'contained' : 'outlined'}
-                                        color={option.color}
-                                        startIcon={option.icon}
                                         onClick={() => {
                                             setRejectionAction(option.action);
                                             if (option.action !== 'requested') setSelectedUser(null);
                                         }}
-                                        sx={{ justifyContent: 'flex-start', textAlign: 'left' }}
+                                        sx={{
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            gap: 1.5,
+                                            p: 1.5,
+                                            borderRadius: 1,
+                                            border: '2px solid',
+                                            borderColor: selected ? 'primary.main' : 'divider',
+                                            backgroundColor: selected ? 'primary.50' : 'transparent',
+                                            cursor: 'pointer',
+                                            transition: 'all 0.15s ease',
+                                            '&:hover': {
+                                                borderColor: selected ? 'primary.main' : 'action.hover',
+                                                backgroundColor: selected ? 'primary.50' : 'action.hover'
+                                            }
+                                        }}
                                     >
-                                        <Box>
-                                            <Typography variant="body2" fontWeight="bold">
+                                        <Box sx={{ color: selected ? 'primary.main' : 'text.secondary', display: 'flex' }}>
+                                            {option.icon}
+                                        </Box>
+                                        <Box sx={{ minWidth: 0 }}>
+                                            <Typography variant="body2" fontWeight={selected ? 600 : 500}>
                                                 {option.label}
                                             </Typography>
-                                            <Typography variant="caption">{option.helper}</Typography>
+                                            <Typography variant="caption" color="text.secondary">
+                                                {option.description}
+                                            </Typography>
                                         </Box>
-                                    </Button>
-                                ))}
-                            </Box>
-                            {rejectionAction === 'requested' && (
-                                <Autocomplete
-                                    sx={{ mt: 2, backgroundColor: 'background.paper' }}
-                                    value={selectedUser}
-                                    loading={isLoadingUsers}
-                                    onChange={(_event: any, newValue: IUser | null) => setSelectedUser(newValue)}
-                                    id={`reassign-requestor-${donation.id}`}
-                                    options={availableUsers}
-                                    getOptionLabel={(user) => `${user.displayName} (${user.email})`}
-                                    isOptionEqualToValue={(option, value) => option.uid === value.uid}
-                                    renderInput={(params) => <TextField {...params} label="New requestor" />}
-                                />
-                            )}
-                        </Alert>
-                        <DialogActions>
-                            <Button
-                                variant="contained"
-                                onClick={() => handleRemove(orderId, donation)}
-                                disabled={isSubmitting || (rejectionAction === 'requested' && !selectedUser)}
-                            >
-                                {isSubmitting ? 'Saving...' : 'Confirm'}
-                            </Button>
-                            <Button variant="outlined" onClick={() => setShowRemoveDialog(false)}>
-                                Cancel
-                            </Button>
-                        </DialogActions>
+                                    </Box>
+                                );
+                            })}
+                        </Box>
+                        {rejectionAction === 'requested' && (
+                            <Autocomplete
+                                sx={{ mt: 2 }}
+                                value={selectedUser}
+                                loading={isLoadingUsers}
+                                onChange={(_event: any, newValue: IUser | null) => setSelectedUser(newValue)}
+                                id={`reassign-requestor-${donation.id}`}
+                                options={availableUsers}
+                                getOptionLabel={(user) => `${user.displayName} (${user.email})`}
+                                isOptionEqualToValue={(option, value) => option.uid === value.uid}
+                                renderInput={(params) => <TextField {...params} label="Select user" size="small" />}
+                            />
+                        )}
                     </DialogContent>
+                    <DialogActions sx={{ px: 3, pb: 2 }}>
+                        <Button
+                            variant="outlined"
+                            onClick={() => setShowRemoveDialog(false)}
+                            sx={{ textTransform: 'none' }}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="contained"
+                            onClick={() => handleRemove(orderId, donation)}
+                            disabled={isSubmitting || (rejectionAction === 'requested' && !selectedUser)}
+                            sx={{ textTransform: 'none' }}
+                        >
+                            {isSubmitting ? 'Saving…' : 'Confirm rejection'}
+                        </Button>
+                    </DialogActions>
                 </Dialog>
             )}
         </ProtectedAdminRoute>

--- a/src/components/ReviewOrder.tsx
+++ b/src/components/ReviewOrder.tsx
@@ -21,6 +21,7 @@ import '@/styles/globalStyles.css';
 //Types
 import { Order } from '@/types/OrdersTypes';
 import { Donation } from '@/models/donation';
+import type { OrderItemRejectionResolution } from '@/api/firebase-donations';
 
 type ReviewOrderProps = {
     id: string;
@@ -50,15 +51,20 @@ const ReviewOrder = (props: ReviewOrderProps) => {
         }
     };
 
-    const handleRemoveFromOrder = async (orderId: string, donation: Donation): Promise<void> => {
+    const handleRemoveFromOrder = async (orderId: string, donation: Donation, resolution: OrderItemRejectionResolution): Promise<void> => {
         setIsLoading(true);
         try {
-            await removeDonationFromOrder(orderId, donation);
+            await removeDonationFromOrder(orderId, donation, resolution);
             if (currentOrder) {
+                const rejectedDonation = new Donation({
+                    ...donation,
+                    status: resolution.action === 'available' ? 'available' : resolution.action === 'requested' ? 'requested' : 'unavailable',
+                    requestor: resolution.action === 'requested' ? resolution.requestor : null
+                });
                 const updatedOrder: Order = {
                     ...currentOrder,
                     items: currentOrder.items.filter((item) => item.id !== donation.id),
-                    rejectedItems: !currentOrder.rejectedItems ? [donation] : [...currentOrder.rejectedItems, donation]
+                    rejectedItems: !currentOrder.rejectedItems ? [rejectedDonation] : [...currentOrder.rejectedItems, rejectedDonation]
                 };
                 setCurrentOrder(updatedOrder);
                 if (updatedOrder.items.length === 0) {

--- a/src/components/ReviewOrder.tsx
+++ b/src/components/ReviewOrder.tsx
@@ -38,6 +38,7 @@ const ReviewOrder = (props: ReviewOrderProps) => {
     const [showScheduler, setShowScheduler] = useState<boolean>(false);
     const [showCancelOrder, setShowCancelOrder] = useState<boolean>(false);
     const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
+    const [dialogContent, setDialogContent] = useState<string>('Donation successfully removed from order');
 
     const fetchOrder = async (id: string): Promise<void> => {
         setIsLoading(true);
@@ -55,23 +56,20 @@ const ReviewOrder = (props: ReviewOrderProps) => {
         setIsLoading(true);
         try {
             await removeDonationFromOrder(orderId, donation, resolution);
-            if (currentOrder) {
-                const rejectedDonation = new Donation({
-                    ...donation,
-                    status: resolution.action === 'available' ? 'available' : resolution.action === 'requested' ? 'requested' : 'unavailable',
-                    requestor: resolution.action === 'requested' ? resolution.requestor : null
-                });
-                const updatedOrder: Order = {
-                    ...currentOrder,
-                    items: currentOrder.items.filter((item) => item.id !== donation.id),
-                    rejectedItems: !currentOrder.rejectedItems ? [rejectedDonation] : [...currentOrder.rejectedItems, rejectedDonation]
-                };
-                setCurrentOrder(updatedOrder);
-                if (updatedOrder.items.length === 0) {
-                    setShowCancelOrder(true);
-                } else {
-                    setIsDialogOpen(true);
-                }
+            const updatedOrder = await getOrderById(orderId);
+            setCurrentOrder(updatedOrder);
+            setNotificationsUpdated?.(true);
+            if (updatedOrder.items.length === 0) {
+                setShowCancelOrder(true);
+            } else {
+                setDialogContent(
+                    resolution.action === 'available'
+                        ? 'Donation returned to available inventory.'
+                        : resolution.action === 'requested'
+                          ? `Donation reassigned to ${resolution.requestor.name}.`
+                          : 'Donation marked as unavailable.'
+                );
+                setIsDialogOpen(true);
             }
         } catch (error) {
             addErrorEvent('Error removing donation from order', error);
@@ -94,7 +92,7 @@ const ReviewOrder = (props: ReviewOrderProps) => {
             {donationIdToDisplay && currentOrder && (
                 <DonationDetails
                     id={donationIdToDisplay}
-                    donation={currentOrder?.items.find((i) => i.id === donationIdToDisplay)}
+                    donation={[...currentOrder.items, ...(currentOrder.rejectedItems ?? [])].find((i) => i.id === donationIdToDisplay)}
                     setIdToDisplay={setDonationIdToDisplay}
                 />
             )}
@@ -156,14 +154,17 @@ const ReviewOrder = (props: ReviewOrderProps) => {
                                     Schedule Pickup
                                 </Button>
                             )}
+<<<<<<< HEAD
                             <Button variant="outlined" color="error" onClick={() => setShowCancelOrder(true)} sx={{ marginLeft: '1rem' }}>
                                 Cancel Order
                             </Button>
+=======
+>>>>>>> 4eef46c (fix: transactional order updates.)
                         </div>
                     )}
                 </>
             )}
-            <CustomDialog isOpen={isDialogOpen} onClose={handleClose} title="Order Updated" content="Donation successfully removed from order" />
+            <CustomDialog isOpen={isDialogOpen} onClose={handleClose} title="Order Updated" content={dialogContent} />
         </ProtectedAdminRoute>
     );
 };

--- a/src/components/ReviewOrder.tsx
+++ b/src/components/ReviewOrder.tsx
@@ -25,7 +25,6 @@ import type { OrderItemRejectionResolution } from '@/api/firebase-donations';
 
 type ReviewOrderProps = {
     id: string;
-    order?: Order;
     setIdToDisplay?: Dispatch<SetStateAction<string | null>>;
     setNotificationsUpdated?: Dispatch<SetStateAction<boolean>>;
 };
@@ -73,6 +72,8 @@ const ReviewOrder = (props: ReviewOrderProps) => {
             }
         } catch (error) {
             addErrorEvent('Error removing donation from order', error);
+            setDialogContent('Something went wrong. Please try again.');
+            setIsDialogOpen(true);
         } finally {
             setIsLoading(false);
         }
@@ -85,6 +86,7 @@ const ReviewOrder = (props: ReviewOrderProps) => {
 
     useEffect(() => {
         fetchOrder(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [id]);
 
     return (
@@ -154,12 +156,9 @@ const ReviewOrder = (props: ReviewOrderProps) => {
                                     Schedule Pickup
                                 </Button>
                             )}
-<<<<<<< HEAD
                             <Button variant="outlined" color="error" onClick={() => setShowCancelOrder(true)} sx={{ marginLeft: '1rem' }}>
                                 Cancel Order
                             </Button>
-=======
->>>>>>> 4eef46c (fix: transactional order updates.)
                         </div>
                     )}
                 </>


### PR DESCRIPTION
### Request summary

When an admin rejects an item, the app now opens a dialog that lets them choose the item’s next status based on the rejection reason:

- Return to inventory sets the item to available
- Reserve for a different user keeps it requested and assigns a new requestor
- Mark as unavailable sets it to unavailable

### Validation

1. Sign in as an admin
2. Go to an order review page with at least one requested item
3. Click Reject on an item
4. Confirm a popup opens with:
       Return to inventory
       Reserve for a different user
       Mark as unavailable
5. Select Return to inventory, confirm, then verify the item is removed from the order and its donation status is available

### Addresses

- #333

[
<img width="1310" height="742" alt="Screenshot 2026-05-15 at 3 43 52 PM" src="https://github.com/user-attachments/assets/cbbd1235-7245-4bf8-b3d0-6bbc35080512" />
](url)