### PR TITLE
feature(notifications): feed navigation

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -52,6 +52,7 @@ export default function Dashboard() {
     const [notificationsSubTab, setNotificationsSubTab] = useState<number>(0);
     const [categories, setCategories] = useState<Category[] | null>(null);
     const pendingNotificationScrollTop = useRef<number | null>(null);
+    const highlightTimer = useRef<ReturnType<typeof setTimeout>>();
 
     const { requestedInventory } = useRequestedInventoryContext();
     const router = useRouter();
@@ -87,10 +88,11 @@ export default function Dashboard() {
     };
 
     const handleFeedNavigation = useCallback((tabIndex: number, entityId: string) => {
+        clearTimeout(highlightTimer.current);
         setCurrentTab(0);
         setNotificationsSubTab(tabIndex);
         setHighlightedEntityId(entityId);
-        window.setTimeout(() => setHighlightedEntityId(null), 5000);
+        highlightTimer.current = setTimeout(() => setHighlightedEntityId(null), 5000);
     }, []);
 
     const setNotificationsUpdatedAndPreserveScroll: React.Dispatch<React.SetStateAction<boolean>> = (value) => {

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -11,8 +11,9 @@ import Loader from './Loader';
 import Notifications from './Notifications';
 import Inventory from './Inventory';
 import Categories from './Categories';
+import NotificationFeed from './NotificationFeed';
 //Hooks
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRequestedInventoryContext } from '@/contexts/RequestedInventoryContext';
 import { useRouter } from 'next/navigation';
 //API
@@ -47,7 +48,10 @@ export default function Dashboard() {
         [key: string]: string;
     } | null>(null);
     const [notifications, setNotifications] = useState<Notification | null>(null);
+    const [highlightedEntityId, setHighlightedEntityId] = useState<string | null>(null);
+    const [notificationsSubTab, setNotificationsSubTab] = useState<number>(0);
     const [categories, setCategories] = useState<Category[] | null>(null);
+    const pendingNotificationScrollTop = useRef<number | null>(null);
 
     const { requestedInventory } = useRequestedInventoryContext();
     const router = useRouter();
@@ -82,16 +86,37 @@ export default function Dashboard() {
         setCurrentTab(target);
     };
 
+    const handleFeedNavigation = useCallback((tabIndex: number, entityId: string) => {
+        setCurrentTab(0);
+        setNotificationsSubTab(tabIndex);
+        setHighlightedEntityId(entityId);
+        window.setTimeout(() => setHighlightedEntityId(null), 5000);
+    }, []);
+
+    const setNotificationsUpdatedAndPreserveScroll: React.Dispatch<React.SetStateAction<boolean>> = (value) => {
+        const updated = typeof value === 'function' ? value(notificationsUpdated) : value;
+        if (updated && typeof window !== 'undefined') {
+            pendingNotificationScrollTop.current = window.scrollY;
+        }
+        setNotificationsUpdated(updated);
+    };
+
     async function fetchNotifications(showLoader = false): Promise<void> {
-        if (showLoader || !notifications) setIsLoading(true);
+        const shouldBlockContent = showLoader || !notifications;
+        if (shouldBlockContent) setIsLoading(true);
         try {
             const notificationsResult = await getNotifications();
             setNotifications(notificationsResult);
             setNotificationsUpdated(false);
+            if (pendingNotificationScrollTop.current !== null) {
+                const scrollTop = pendingNotificationScrollTop.current;
+                pendingNotificationScrollTop.current = null;
+                requestAnimationFrame(() => window.scrollTo({ top: scrollTop }));
+            }
         } catch (error) {
             addErrorEvent('Fetch notifications', error);
         } finally {
-            setIsLoading(false);
+            if (shouldBlockContent) setIsLoading(false);
         }
     }
 
@@ -215,7 +240,8 @@ export default function Dashboard() {
                         </Menu>
                     </>
                 )}
-                <IconButton onClick={handleRefresh} size="small" sx={{ ml: 'auto' }}>
+                <NotificationFeed notifications={notifications} onNavigate={handleFeedNavigation} />
+                <IconButton onClick={handleRefresh} size="small" sx={{ ml: 0.5 }}>
                     <RefreshIcon fontSize="small" />
                 </IconButton>
             </div>
@@ -226,7 +252,13 @@ export default function Dashboard() {
 
                     <CustomTabPanel value={currentTab} index={0}>
                         {notifications ? (
-                            <Notifications notifications={notifications} setNotificationsUpdated={setNotificationsUpdated} />
+                            <Notifications
+                                notifications={notifications}
+                                setNotificationsUpdated={setNotificationsUpdatedAndPreserveScroll}
+                                activeSubTab={notificationsSubTab}
+                                onSubTabChange={setNotificationsSubTab}
+                                highlightedEntityId={highlightedEntityId}
+                            />
                         ) : (
                             <p>No notifications at this time.</p>
                         )}

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 //Hooks
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 //Components
 import Link from 'next/link';
@@ -45,19 +45,30 @@ type NotificationCardProps = {
     order?: Order;
     setIdToDisplay: Dispatch<SetStateAction<string | null>>;
     setNotificationsUpdated?: Dispatch<SetStateAction<boolean>>;
+    isHighlighted?: boolean;
 };
 
 //TO-DO: Set up buttons
 const NotificationCard = (props: NotificationCardProps) => {
-    const { type, donation, user, order, setIdToDisplay, setNotificationsUpdated } = props;
+    const { type, donation, user, order, setIdToDisplay, setNotificationsUpdated, isHighlighted } = props;
 
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false);
     const [dialogTitle, setDialogTitle] = useState<string>('');
     const [dialogContent, setDialogContent] = useState<string>('');
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState<boolean>(false);
+    const cardRef = useRef<HTMLDivElement>(null);
+    const highlightedSx = isHighlighted
+        ? { boxShadow: '0 0 0 2px #ffc107, 0 4px 16px rgba(255, 193, 7, 0.25)', transition: 'box-shadow 0.4s ease' }
+        : undefined;
 
     const router = useRouter();
+
+    useEffect(() => {
+        if (isHighlighted) {
+            cardRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+    }, [isHighlighted]);
 
     const handleClose = () => {
         setIsDialogOpen(false);
@@ -158,7 +169,7 @@ const NotificationCard = (props: NotificationCardProps) => {
     return (
         <ProtectedAdminRoute>
             {type === 'pending-donation' && donation && (
-                <Card className={styles['notification-card']} variant="outlined">
+                <Card ref={cardRef} className={styles['notification-card']} variant="outlined" sx={highlightedSx}>
                     <div className={styles['notification-card--group']}>
                         <CardActions className={styles['notification-card--image']} onClick={() => setIdToDisplay(donation.id)}>
                             <CardMedia component="img" alt={donation.model} image={donation.images[0]} />
@@ -181,7 +192,7 @@ const NotificationCard = (props: NotificationCardProps) => {
                     {isLoading ? (
                         <Loader />
                     ) : (
-                        <Card className={styles['notification-card']} variant="outlined">
+                        <Card ref={cardRef} className={styles['notification-card']} variant="outlined" sx={highlightedSx}>
                             <div className={styles['notification-card--group']}>
                                 <CardActions className={styles['notification-card--image']} onClick={() => setIdToDisplay(donation.id)}>
                                     <CardMedia component="img" alt={donation.model} image={donation.images[0]} />
@@ -220,7 +231,7 @@ const NotificationCard = (props: NotificationCardProps) => {
                     {isLoading ? (
                         <Loader />
                     ) : (
-                        <Card className={styles['notification-card']} variant="outlined">
+                        <Card ref={cardRef} className={styles['notification-card']} variant="outlined" sx={highlightedSx}>
                             <div className={styles['notification-card--group']}>
                                 <CardActions className={styles['notification-card--image']} onClick={() => setIdToDisplay(donation.id)}>
                                     <CardMedia component="img" alt={donation.model} image={donation.images[0]} />
@@ -257,7 +268,7 @@ const NotificationCard = (props: NotificationCardProps) => {
                 </>
             )}
             {type === 'order' && donation && (
-                <Card className={styles['notification-card']} variant="outlined">
+                <Card ref={cardRef} className={styles['notification-card']} variant="outlined" sx={highlightedSx}>
                     <div className={styles['notification-card--group']}>
                         <CardActions className={styles['notification-card--image']} onClick={() => setIdToDisplay(donation.id)}>
                             <CardMedia component="img" alt={donation.model} image={donation.images[0]} />
@@ -281,7 +292,7 @@ const NotificationCard = (props: NotificationCardProps) => {
                         <Loader />
                     ) : (
                         <>
-                            <Card className={styles['notification-card']} variant="outlined">
+                            <Card ref={cardRef} className={styles['notification-card']} variant="outlined" sx={highlightedSx}>
                                 <CardActions onClick={() => setIdToDisplay(user.uid)} sx={{ width: '100%' }}>
                                     <CardContent className={styles['notification-card--info']}>
                                         <Typography variant="h5">{user.displayName}</Typography>

--- a/src/components/NotificationFeed.module.css
+++ b/src/components/NotificationFeed.module.css
@@ -129,10 +129,15 @@
     color: #333;
 }
 
-.feed-chip--active {
+.feed-chip--active,
+.feed-chip--active:hover {
     border-color: #1a1a1a;
     background: #1a1a1a;
     color: #fff;
+}
+
+.feed-chip--active .feed-chip-count {
+    opacity: 1;
 }
 
 .feed-chip-count {

--- a/src/components/NotificationFeed.module.css
+++ b/src/components/NotificationFeed.module.css
@@ -1,0 +1,274 @@
+.feed-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.18);
+    z-index: 1200;
+}
+
+.feed-panel {
+    position: fixed;
+    top: env(safe-area-inset-top, 0);
+    right: 0;
+    bottom: env(safe-area-inset-bottom, 0);
+    z-index: 1300;
+    display: flex;
+    width: min(42rem, calc(100dvw - 16px));
+    max-height: 100dvh;
+    flex-direction: column;
+    overflow: hidden;
+    background: #fff;
+    box-shadow: -6px 0 32px rgba(0, 0, 0, 0.1);
+}
+
+.feed-header {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 16px 20px 12px;
+    border-bottom: 1px solid #eaeaea;
+}
+
+.feed-header h3 {
+    margin: 0;
+    overflow: hidden;
+    color: #1a1a1a;
+    font-size: 1.05rem;
+    font-weight: 600;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.feed-search {
+    display: grid;
+    flex-shrink: 0;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 8px;
+    margin: 0 20px;
+    padding: 8px 10px;
+    border: 1px solid #ececec;
+    border-radius: 8px;
+    background: #fafafa;
+}
+
+.feed-search-icon {
+    color: #777;
+}
+
+.feed-search-input {
+    width: 100%;
+    min-width: 0;
+    border: 0;
+    outline: 0;
+    background: transparent;
+    color: #222;
+    font: inherit;
+    font-size: 0.8125rem;
+}
+
+.feed-search-clear {
+    display: inline-flex;
+    width: 24px;
+    height: 24px;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 0;
+    border-radius: 50%;
+    background: transparent;
+    color: #777;
+    cursor: pointer;
+}
+
+.feed-search-clear:hover {
+    background: #eee;
+    color: #333;
+}
+
+.feed-trigger {
+    gap: 4px;
+    border-radius: 8px;
+}
+
+.feed-trigger-count {
+    min-width: 1.25rem;
+    color: #555;
+    font-size: 0.72rem;
+    font-weight: 600;
+    line-height: 1;
+}
+
+.feed-filters {
+    display: flex;
+    flex-shrink: 0;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 10px 20px;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.feed-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    background: #fff;
+    color: #666;
+    cursor: pointer;
+    font-size: 0.75rem;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.feed-chip:hover {
+    border-color: #bbb;
+    color: #333;
+}
+
+.feed-chip--active {
+    border-color: #1a1a1a;
+    background: #1a1a1a;
+    color: #fff;
+}
+
+.feed-chip-count {
+    color: inherit;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    opacity: 0.72;
+}
+
+.feed-list {
+    flex: 1;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding: 8px 0;
+}
+
+.feed-empty {
+    padding: 48px 20px;
+    color: #999;
+    font-size: 0.875rem;
+    text-align: center;
+}
+
+.feed-item {
+    display: flex;
+    width: 100%;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 20px;
+    border: 0;
+    border-bottom: 1px solid #f5f5f5;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+}
+
+.feed-item:hover {
+    background: #fafafa;
+}
+
+.feed-item-icon {
+    display: flex;
+    width: 36px;
+    height: 36px;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    border-radius: 10px;
+}
+
+.feed-item-icon--donation {
+    background: #e3f2fd;
+    color: #1976d2;
+}
+
+.feed-item-icon--user {
+    background: #f3e5f5;
+    color: #7b1fa2;
+}
+
+.feed-item-icon--order {
+    background: #fff3e0;
+    color: #e65100;
+}
+
+.feed-item-content {
+    display: flex;
+    min-width: 0;
+    flex: 1;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.feed-item-title {
+    overflow-wrap: anywhere;
+    color: #1a1a1a;
+    font-size: 0.8125rem;
+    font-weight: 600;
+}
+
+.feed-item-subtitle {
+    overflow: hidden;
+    color: #888;
+    font-size: 0.75rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.feed-item-tags {
+    color: #666;
+    font-size: 0.72rem;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+}
+
+.feed-item-tags span {
+    color: #888;
+    font-weight: 600;
+}
+
+.feed-item-time {
+    flex-shrink: 0;
+    margin-top: 2px;
+    color: #aaa;
+    font-size: 0.6875rem;
+    white-space: nowrap;
+}
+
+@media screen and (max-width: 480px) {
+    .feed-panel {
+        width: 100dvw;
+    }
+
+    .feed-header,
+    .feed-filters {
+        padding-right: 14px;
+        padding-left: 14px;
+    }
+
+    .feed-search {
+        margin-right: 14px;
+        margin-left: 14px;
+    }
+
+    .feed-item {
+        display: grid;
+        grid-template-columns: 36px minmax(0, 1fr);
+        gap: 8px 10px;
+        padding: 12px 14px;
+    }
+
+    .feed-item-time {
+        grid-column: 2;
+        margin-top: -2px;
+    }
+}

--- a/src/components/NotificationFeed.tsx
+++ b/src/components/NotificationFeed.tsx
@@ -1,0 +1,345 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { IconButton, Tooltip } from '@mui/material';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+import CloseIcon from '@mui/icons-material/Close';
+import SearchIcon from '@mui/icons-material/Search';
+import VolunteerActivismIcon from '@mui/icons-material/VolunteerActivism';
+import LocalShippingIcon from '@mui/icons-material/LocalShipping';
+import PersonAddIcon from '@mui/icons-material/PersonAdd';
+import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
+import BookmarkIcon from '@mui/icons-material/Bookmark';
+import { Donation } from '@/models/donation';
+import { Notification } from '@/types/NotificationTypes';
+import styles from './NotificationFeed.module.css';
+
+type NotificationFilterType = 'all' | 'pending-donations' | 'pending-deliveries' | 'pending-users' | 'requested-equipment' | 'reserved';
+type EntityType = 'donation' | 'user' | 'order';
+type DateLike = string | Date | { toDate?: () => Date; toMillis?: () => number } | null | undefined;
+
+type NotificationFeedItem = {
+    id: string;
+    type: Exclude<NotificationFilterType, 'all'>;
+    title: string;
+    subtitle: string;
+    timestamp: Date;
+    entityId: string;
+    entityType: EntityType;
+    tabIndex: number;
+    searchText: string;
+    tagNumbers: string[];
+};
+
+type NotificationFeedProps = {
+    notifications: Notification | null;
+    onNavigate: (tabIndex: number, entityId: string) => void;
+};
+
+const filters: { key: NotificationFilterType; label: string }[] = [
+    { key: 'all', label: 'All' },
+    { key: 'pending-deliveries', label: 'Deliveries' },
+    { key: 'pending-donations', label: 'Donations' },
+    { key: 'pending-users', label: 'Users' },
+    { key: 'requested-equipment', label: 'Requested' },
+    { key: 'reserved', label: 'Reserved' }
+];
+
+function normalize(value: unknown): string {
+    return String(value ?? '').toLowerCase().trim();
+}
+
+function toDate(timestamp: DateLike): Date {
+    if (!timestamp) return new Date();
+    if (timestamp instanceof Date) return timestamp;
+    if (typeof timestamp === 'string') {
+        const parsed = new Date(timestamp);
+        return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+    }
+    if (timestamp.toMillis) return new Date(timestamp.toMillis());
+    if (timestamp.toDate) return timestamp.toDate();
+    return new Date();
+}
+
+function donationFields(donation?: Donation): unknown[] {
+    if (!donation) return [];
+    return [
+        donation.tagNumber,
+        donation.model,
+        donation.brand,
+        donation.category,
+        donation.description,
+        donation.id,
+        donation.donorName,
+        donation.donorEmail,
+        donation.requestor?.name,
+        donation.requestor?.email
+    ];
+}
+
+function createSearchText(fields: unknown[]): string {
+    return fields.map(normalize).join(' ');
+}
+
+function buildFeedItems(notifications: Notification | null): NotificationFeedItem[] {
+    if (!notifications) return [];
+
+    const items: NotificationFeedItem[] = [];
+
+    notifications.donations
+        .filter((donation) => donation.status === 'in processing')
+        .forEach((donation) => {
+            items.push({
+                id: `pending-donation-${donation.id}`,
+                type: 'pending-donations',
+                title: `${donation.brand} - ${donation.model}`,
+                subtitle: `Donated by ${donation.donorName}`,
+                timestamp: toDate(donation.createdAt),
+                entityId: donation.id,
+                entityType: 'donation',
+                tabIndex: 0,
+                searchText: createSearchText(donationFields(donation)),
+                tagNumbers: donation.tagNumber ? [donation.tagNumber] : []
+            });
+        });
+
+    notifications.donations
+        .filter((donation) => donation.status === 'pending delivery')
+        .forEach((donation) => {
+            items.push({
+                id: `pending-delivery-${donation.id}`,
+                type: 'pending-deliveries',
+                title: `${donation.brand} - ${donation.model}`,
+                subtitle: `Drop-off pending from ${donation.donorName}`,
+                timestamp: toDate(donation.dateAccepted),
+                entityId: donation.id,
+                entityType: 'donation',
+                tabIndex: 1,
+                searchText: createSearchText(donationFields(donation)),
+                tagNumbers: donation.tagNumber ? [donation.tagNumber] : []
+            });
+        });
+
+    notifications.orders
+        .filter((order) => order.items.length > 0)
+        .forEach((order) => {
+            const tagNumbers = order.items.flatMap((donation) => (donation.tagNumber ? [donation.tagNumber] : []));
+            items.push({
+                id: `order-${order.id}`,
+                type: 'requested-equipment',
+                title: `${order.requestor.name} - ${order.items.length} item${order.items.length !== 1 ? 's' : ''}`,
+                subtitle: 'Equipment request pending review',
+                timestamp: toDate(order.createdAt as DateLike),
+                entityId: order.id,
+                entityType: 'order',
+                tabIndex: 2,
+                searchText: createSearchText([order.id, order.requestor.name, order.requestor.email, ...order.items.flatMap(donationFields)]),
+                tagNumbers: [...new Set(tagNumbers)]
+            });
+        });
+
+    notifications.donations
+        .filter((donation) => donation.status === 'reserved')
+        .forEach((donation) => {
+            items.push({
+                id: `reserved-${donation.id}`,
+                type: 'reserved',
+                title: `${donation.brand} - ${donation.model}`,
+                subtitle: `Reserved by ${donation.requestor?.name ?? 'Unknown'}`,
+                timestamp: toDate(donation.dateRequested),
+                entityId: donation.id,
+                entityType: 'donation',
+                tabIndex: 3,
+                searchText: createSearchText(donationFields(donation)),
+                tagNumbers: donation.tagNumber ? [donation.tagNumber] : []
+            });
+        });
+
+    notifications.users
+        .filter((user) => !user.isDeleted)
+        .forEach((user) => {
+            items.push({
+                id: `user-${user.uid}`,
+                type: 'pending-users',
+                title: user.displayName,
+                subtitle: `${user.email} awaiting approval`,
+                timestamp: toDate(user.createdAt as DateLike),
+                entityId: user.uid,
+                entityType: 'user',
+                tabIndex: 4,
+                searchText: createSearchText([user.uid, user.displayName, user.email, user.organization?.name, user.phoneNumber]),
+                tagNumbers: []
+            });
+        });
+
+    return items.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+}
+
+function timeAgo(date: Date): string {
+    const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+    if (seconds < 60) return 'just now';
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days === 1) return 'yesterday';
+    if (days < 30) return `${days}d ago`;
+    return date.toLocaleDateString();
+}
+
+function getItemIcon(type: NotificationFeedItem['type']) {
+    switch (type) {
+        case 'pending-donations':
+            return <VolunteerActivismIcon fontSize="small" />;
+        case 'pending-deliveries':
+            return <LocalShippingIcon fontSize="small" />;
+        case 'pending-users':
+            return <PersonAddIcon fontSize="small" />;
+        case 'requested-equipment':
+            return <ShoppingCartIcon fontSize="small" />;
+        case 'reserved':
+            return <BookmarkIcon fontSize="small" />;
+    }
+}
+
+export default function NotificationFeed({ notifications, onNavigate }: NotificationFeedProps) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [activeFilter, setActiveFilter] = useState<NotificationFilterType>('all');
+    const [searchInput, setSearchInput] = useState('');
+
+    const items = useMemo(() => buildFeedItems(notifications), [notifications]);
+    const normalizedSearchInput = normalize(searchInput);
+    const filteredItems = useMemo(() => {
+        const filteredByType = activeFilter === 'all' ? items : items.filter((item) => item.type === activeFilter);
+        if (!normalizedSearchInput) return filteredByType;
+        return filteredByType.filter((item) => item.searchText.includes(normalizedSearchInput) || item.title.toLowerCase().includes(normalizedSearchInput));
+    }, [activeFilter, items, normalizedSearchInput]);
+
+    const filterCounts = useMemo<Record<NotificationFilterType, number>>(
+        () => ({
+            all: items.length,
+            'pending-deliveries': items.filter((item) => item.type === 'pending-deliveries').length,
+            'pending-donations': items.filter((item) => item.type === 'pending-donations').length,
+            'pending-users': items.filter((item) => item.type === 'pending-users').length,
+            'requested-equipment': items.filter((item) => item.type === 'requested-equipment').length,
+            reserved: items.filter((item) => item.type === 'reserved').length
+        }),
+        [items]
+    );
+
+    const handleClose = useCallback(() => setIsOpen(false), []);
+    const handleItemClick = useCallback(
+        (item: NotificationFeedItem) => {
+            onNavigate(item.tabIndex, item.entityId);
+        },
+        [onNavigate]
+    );
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') handleClose();
+        };
+
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [handleClose]);
+
+    return (
+        <>
+            <Tooltip title="Notifications">
+                <IconButton
+                    className={styles['feed-trigger']}
+                    onClick={() => setIsOpen(true)}
+                    size="small"
+                    sx={{ color: '#666' }}
+                    aria-label={`Open notifications feed, ${items.length} notifications`}
+                >
+                    <NotificationsIcon fontSize="small" />
+                    <span className={styles['feed-trigger-count']}>{items.length}</span>
+                </IconButton>
+            </Tooltip>
+
+            {isOpen &&
+                typeof document !== 'undefined' &&
+                createPortal(
+                    <>
+                        <div className={styles['feed-backdrop']} onClick={handleClose} />
+                        <div className={styles['feed-panel']} role="dialog" aria-modal="true" aria-label="Notifications">
+                            <div className={styles['feed-header']}>
+                                <h3>Notifications</h3>
+                                <Tooltip title="Close">
+                                    <IconButton size="small" onClick={handleClose}>
+                                        <CloseIcon fontSize="small" />
+                                    </IconButton>
+                                </Tooltip>
+                            </div>
+
+                            <div className={styles['feed-search']}>
+                                <SearchIcon className={styles['feed-search-icon']} fontSize="small" />
+                                <input
+                                    aria-label="Search notifications"
+                                    className={styles['feed-search-input']}
+                                    type="search"
+                                    placeholder="Search TAG, model, brand, or person"
+                                    value={searchInput}
+                                    onChange={(event) => setSearchInput(event.target.value)}
+                                />
+                                {searchInput && (
+                                    <button
+                                        aria-label="Clear notification search"
+                                        className={styles['feed-search-clear']}
+                                        type="button"
+                                        onClick={() => setSearchInput('')}
+                                    >
+                                        <CloseIcon fontSize="small" />
+                                    </button>
+                                )}
+                            </div>
+
+                            <div className={styles['feed-filters']}>
+                                {filters.map((filter) => (
+                                    <button
+                                        key={filter.key}
+                                        className={`${styles['feed-chip']} ${activeFilter === filter.key ? styles['feed-chip--active'] : ''}`}
+                                        onClick={() => setActiveFilter(filter.key)}
+                                    >
+                                        <span>{filter.label}</span>
+                                        <span className={styles['feed-chip-count']}>{filterCounts[filter.key]}</span>
+                                    </button>
+                                ))}
+                            </div>
+
+                            <div className={styles['feed-list']}>
+                                {filteredItems.length === 0 ? (
+                                    <div className={styles['feed-empty']}>
+                                        {normalizedSearchInput ? 'No notifications match this search.' : 'No notifications matching this filter.'}
+                                    </div>
+                                ) : (
+                                    filteredItems.map((item) => (
+                                        <button key={item.id} className={styles['feed-item']} type="button" onClick={() => handleItemClick(item)}>
+                                            <span className={`${styles['feed-item-icon']} ${styles[`feed-item-icon--${item.entityType}`]}`}>
+                                                {getItemIcon(item.type)}
+                                            </span>
+                                            <span className={styles['feed-item-content']}>
+                                                <span className={styles['feed-item-title']}>{item.title}</span>
+                                                <span className={styles['feed-item-subtitle']}>{item.subtitle}</span>
+                                                {item.tagNumbers.length > 0 && (
+                                                    <span className={styles['feed-item-tags']}>
+                                                        <span>TAG</span> {item.tagNumbers.join(', ')}
+                                                    </span>
+                                                )}
+                                            </span>
+                                            <span className={styles['feed-item-time']}>{timeAgo(item.timestamp)}</span>
+                                        </button>
+                                    ))
+                                )}
+                            </div>
+                        </div>
+                    </>,
+                    document.body
+                )}
+        </>
+    );
+}

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -21,6 +21,9 @@ import { Order } from '@/types/OrdersTypes';
 type NotificationsProps = {
     notifications: Notification;
     setNotificationsUpdated?: Dispatch<SetStateAction<boolean>>;
+    activeSubTab?: number;
+    onSubTabChange?: Dispatch<SetStateAction<number>>;
+    highlightedEntityId?: string | null;
 };
 
 type DonorGroup = {
@@ -36,6 +39,24 @@ type RequestorGroup = {
     requestorId: string;
     orders: Order[];
     totalItems: number;
+};
+
+type DateLike = { toMillis?: () => number; toDate?: () => Date } | Date | string | null | undefined;
+
+const toDateValue = (date: DateLike): Date | null => {
+    if (!date) return null;
+    if (date instanceof Date) return date;
+    if (typeof date === 'string') {
+        const parsed = new Date(date);
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
+    }
+    if (date.toMillis) return new Date(date.toMillis());
+    if (date.toDate) return date.toDate();
+    return null;
+};
+
+const formatShortDate = (date: DateLike): string => {
+    return toDateValue(date)?.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) ?? '';
 };
 
 const groupByDonor = (donations: Donation[]): DonorGroup[] => {
@@ -85,12 +106,22 @@ const groupByRequestor = (orders: Order[]): RequestorGroup[] => {
 };
 
 const Notifications = (props: NotificationsProps) => {
-    const { notifications, setNotificationsUpdated } = props;
+    const { notifications, setNotificationsUpdated, activeSubTab, onSubTabChange, highlightedEntityId } = props;
 
     const [donationIdToDisplay, setDonationIdToDisplay] = useState<string | null>(null);
     const [userIdToDisplay, setUserIdToDisplay] = useState<string | null>(null);
     const [orderIdToDisplay, setOrderIdToDisplay] = useState<string | null>(null);
-    const [currentTab, setCurrentTab] = useState<number>(0);
+    const [localSubTab, setLocalSubTab] = useState<number>(0);
+    const currentTab = activeSubTab ?? localSubTab;
+
+    const handleSubTabChange = (nextTab: number) => {
+        if (onSubTabChange) {
+            onSubTabChange(nextTab);
+            return;
+        }
+
+        setLocalSubTab(nextTab);
+    };
 
     const donationsAwaitingApproval = notifications.donations.filter((donation) => donation.status === 'in processing');
     const donorGroupsApproval = groupByDonor(donationsAwaitingApproval);
@@ -142,7 +173,7 @@ const Notifications = (props: NotificationsProps) => {
                         <>
                             <Tabs
                                 value={currentTab}
-                                onChange={(_, v) => setCurrentTab(v)}
+                                onChange={(_, v) => handleSubTabChange(v)}
                                 variant="scrollable"
                                 scrollButtons="auto"
                                 sx={{
@@ -211,6 +242,7 @@ const Notifications = (props: NotificationsProps) => {
                                                             type="pending-donation"
                                                             setIdToDisplay={setDonationIdToDisplay}
                                                             setNotificationsUpdated={setNotificationsUpdated}
+                                                            isHighlighted={highlightedEntityId === donation.id}
                                                         />
                                                     ))}
                                                 </>
@@ -247,6 +279,7 @@ const Notifications = (props: NotificationsProps) => {
                                                                     type="pending-donation"
                                                                     setIdToDisplay={setDonationIdToDisplay}
                                                                     setNotificationsUpdated={setNotificationsUpdated}
+                                                                    isHighlighted={highlightedEntityId === donation.id}
                                                                 />
                                                             ))}
                                                         </Box>
@@ -280,6 +313,7 @@ const Notifications = (props: NotificationsProps) => {
                                                     type="pending-delivery"
                                                     setIdToDisplay={setDonationIdToDisplay}
                                                     setNotificationsUpdated={setNotificationsUpdated}
+                                                    isHighlighted={highlightedEntityId === donation.id}
                                                 />
                                             ))}
                                         </Paper>
@@ -318,6 +352,7 @@ const Notifications = (props: NotificationsProps) => {
                                                             donation={item}
                                                             setIdToDisplay={setDonationIdToDisplay}
                                                             setNotificationsUpdated={setNotificationsUpdated}
+                                                            isHighlighted={highlightedEntityId === group.orders[0].id || highlightedEntityId === item.id}
                                                         />
                                                     ))}
                                                 </>
@@ -343,7 +378,7 @@ const Notifications = (props: NotificationsProps) => {
                                                             }}>
                                                                 <Typography variant="caption" color="text.secondary">
                                                                     {`${order.items.length} item${order.items.length !== 1 ? 's' : ''}`}
-                                                                    {order.createdAt && ` — ${order.createdAt.toDate().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`}
+                                                                    {order.createdAt && ` - ${formatShortDate(order.createdAt)}`}
                                                                 </Typography>
                                                                 <Button
                                                                     size="small"
@@ -360,6 +395,7 @@ const Notifications = (props: NotificationsProps) => {
                                                                     donation={item}
                                                                     setIdToDisplay={setDonationIdToDisplay}
                                                                     setNotificationsUpdated={setNotificationsUpdated}
+                                                                    isHighlighted={highlightedEntityId === order.id || highlightedEntityId === item.id}
                                                                 />
                                                             ))}
                                                         </Box>
@@ -393,6 +429,7 @@ const Notifications = (props: NotificationsProps) => {
                                                     type="reserved"
                                                     setIdToDisplay={setDonationIdToDisplay}
                                                     setNotificationsUpdated={setNotificationsUpdated}
+                                                    isHighlighted={highlightedEntityId === donation.id}
                                                 />
                                             ))}
                                         </Paper>
@@ -414,6 +451,7 @@ const Notifications = (props: NotificationsProps) => {
                                             user={user}
                                             setIdToDisplay={setUserIdToDisplay}
                                             setNotificationsUpdated={setNotificationsUpdated}
+                                            isHighlighted={highlightedEntityId === user.uid}
                                         />
                                     ))
                                 ) : (


### PR DESCRIPTION

# Notification Feed PR Review

This PR adds the notification feed panel and the supporting feed data model. It introduces a dashboard bell/feed entry point, searchable and filterable notification items, Calendly booking status badges, highlighted navigation into notification tabs, and a skeleton loading state for feed cards.

This does **not** include the SWR dashboard present in #340

<img width="1315" height="735" alt="Screenshot 2026-05-15 at 5 03 49 PM" src="https://github.com/user-attachments/assets/956f467d-7749-48b3-a6ed-b241a3c90015" />

## Main Changes

| Area | Change |
| --- | --- |
| Feed data | Adds `src/api/notificationData.ts` to compute normalized notification feed items from donations, orders, users, and booking status data. |
| Server actions | Adds `fetchNotificationFeedData` in `src/app/actions/firebase.ts` so the feed can load enriched notification metadata. |
| Feed UI | Adds `NotificationFeed.tsx` and `NotificationFeed.module.css` for the slide-out notification panel. |
| Search/filtering | Supports filtering by notification type and searching by tag, donor, requestor, pending user, model, and brand. |
| Booking state | Shows Calendly booking confidence on feed items and notification cards for pending delivery/pickup items. |
| Dashboard integration | Adds the feed button to `Dashboard.tsx` and preserves dashboard context when navigating from the feed into notification subtabs. |
| Loading state | Updates `Loader.tsx` / `Loader.module.css` with a skeleton outline loader used by the feed. |
| Timestamp handling | Normalizes timestamp/date rendering so Firestore timestamps and serialized dates render safely. |

## Reviewer Focus

| Area | Suggested Check |
| --- | --- |
| Feed opening/closing | Open the notification bell, expand/collapse the panel, close with the close button/backdrop/Escape. |
| Feed filters | Check All, Deliveries, Donations, Users, Requested, Reserved, and Unconfirmed filters. |
| Feed search | Search by tag number, donor name, requestor name, pending user name, model, and brand. |
| Navigation | Click feed items and confirm the dashboard switches to the correct notification sub-tab and highlights the intended item. |
| Calendly status | Confirm pending delivery and pickup items show the expected booked/maybe/no booking state. |
| Responsive layout | Resize to mobile width and verify chips wrap/scroll and cards stay inside the panel. |
| Loader | Confirm the skeleton loader appears cleanly while feed data is loading. |