### PR TITLE
fix(user-accounts): users without assigned organizations

### DIFF
--- a/src/api/firebase-donations.ts
+++ b/src/api/firebase-donations.ts
@@ -840,49 +840,61 @@ export async function removeDonationFromOrder(
 //Marks donation as distributed and adds it to user's and organization's distributed items list
 export async function markDonationAsDistributed(donation: Donation): Promise<void> {
     try {
-        const batch = writeBatch(db);
         const donationRef = doc(db, `${DONATIONS_COLLECTION}/${donation.id}`).withConverter(donationConverter);
-        const requestorRef = doc(db, `${USERS_COLLECTION}/${donation.requestor?.id}`);
-        const requestorSnapshot = await getDoc(requestorRef);
-        let orgId = '';
-        if (requestorSnapshot.exists()) {
-            const requestor = requestorSnapshot.data();
-            orgId = requestor.organization.id;
-        }
-        const organizationRef = doc(db, ORGANIZATIONS_COLLECTION, orgId);
-        const organizationSnapshot = await getDoc(organizationRef);
-        let orgName;
-        if (organizationSnapshot.exists()) {
-            orgName = organizationSnapshot.data().name;
+        if (!donation.requestor?.id) {
+            throw new Error('Donation has no requestor.');
         }
 
-        batch.update(donationRef, {
-            status: 'distributed',
-            distributor: {
-                id: donation.requestor?.id,
-                name: donation.requestor?.name,
-                email: donation.requestor?.email,
-                organization: orgName
-            },
-            modifiedAt: serverTimestamp(),
-            dateDistributed: serverTimestamp()
+        const requestorRef = doc(db, USERS_COLLECTION, donation.requestor.id);
+
+        await runTransaction(db, async (transaction) => {
+            const requestorSnapshot = await transaction.get(requestorRef);
+            if (!requestorSnapshot.exists()) {
+                throw new Error('Requestor not found.');
+            }
+
+            const requestor = requestorSnapshot.data();
+            const orgId = requestor.organization?.id;
+            let orgName: string | undefined = requestor.organization?.name;
+            const organizationRef = orgId ? doc(db, ORGANIZATIONS_COLLECTION, orgId) : null;
+
+            if (organizationRef) {
+                const organizationSnapshot = await transaction.get(organizationRef);
+                if (organizationSnapshot.exists()) {
+                    orgName = organizationSnapshot.data().name;
+                }
+            }
+
+            transaction.update(donationRef, {
+                status: 'distributed',
+                distributor: {
+                    id: donation.requestor?.id,
+                    name: donation.requestor?.name,
+                    email: donation.requestor?.email,
+                    organization: orgName ?? 'Unassigned'
+                },
+                modifiedAt: serverTimestamp(),
+                dateDistributed: serverTimestamp()
+            });
+            transaction.update(requestorRef, {
+                distributedItems: arrayUnion({
+                    id: donation.id,
+                    tagNumber: donation.tagNumber
+                }),
+                modifiedAt: serverTimestamp()
+            });
+            if (organizationRef) {
+                transaction.update(organizationRef, {
+                    distributedItems: arrayUnion({
+                        id: donation.id,
+                        tagNumber: donation.tagNumber
+                    }),
+                    modifiedAt: serverTimestamp()
+                });
+            }
         });
-        batch.update(requestorRef, {
-            distributedItems: arrayUnion({
-                id: donation.id,
-                tagNumber: donation.tagNumber
-            }),
-            modifiedAt: serverTimestamp()
-        });
-        batch.update(organizationRef, {
-            distributedItems: arrayUnion({
-                id: donation.id,
-                tagNumber: donation.tagNumber
-            }),
-            modifiedAt: serverTimestamp()
-        });
-        await batch.commit();
     } catch (error) {
         addErrorEvent('Error marking donation as distributed', error);
+        throw error;
     }
 }

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -36,7 +36,6 @@ import { Order } from '@/types/OrdersTypes';
 import { IUser } from '@/models/user';
 
 import rejectUser from '@/email-templates/rejectUser';
-import userEnabled from '@/email-templates/userEnabled';
 
 type NotificationCardProps = {
     type: 'pending-donation' | 'pending-delivery' | 'reserved' | 'order' | 'pending-user';
@@ -132,12 +131,10 @@ const NotificationCard = (props: NotificationCardProps) => {
         }
     };
 
-    const handleEnableUser = async (uid: string, userName: string, userEmail: string): Promise<void> => {
+    const handleEnableUser = async (uid: string, userName: string): Promise<void> => {
         setIsLoading(true);
         try {
             await enableUser({ idToken: await getAuthIdToken(), userId: uid });
-            const msg = userEnabled(userEmail, userName);
-            await sendMail(msg);
             setDialogTitle('User enabled');
             setDialogContent(`The user ${userName} has been enabled.`);
             setIsDialogOpen(true);
@@ -311,8 +308,7 @@ const NotificationCard = (props: NotificationCardProps) => {
                                 <CardActions className={styles['notification-card--container--btn']}>
                                     <Button
                                         variant="contained"
-                                        onClick={() => handleEnableUser(user.uid, user.displayName, user.email)}
-                                        disabled={!user.organization}
+                                        onClick={() => handleEnableUser(user.uid, user.displayName)}
                                     >
                                         Approve
                                     </Button>


### PR DESCRIPTION
This request introduces support for approving and distributing items for users without organizations.

- Allow pending users without an organization to be approved from notification cards
- Update donation distribution to handle requestors without organizations by recording the distributor organization as `Unassigned`
- Only write `distributed item` history to an organization when the requestor has a valid organization
- Removes duplicate "user enabled" email sending from the notification card flow
- Validate that the donation has a requestor and that the requestor still exists before marking the donation distributed
