### PR TITLE
fix: correct fufilled to fulfilled typo in schedulePickup email subject

### DIFF
--- a/src/email-templates/schedulePickup.ts
+++ b/src/email-templates/schedulePickup.ts
@@ -22,7 +22,7 @@ export default function schedulePickup(email: string, inviteUrl: string, message
         to: email,
         cc: emailCc,
         from: emailSender,
-        subject: 'Your Baby Product Exchange order has been fufilled',
+        subject: 'Your Baby Product Exchange order has been fulfilled',
         html: html
     };
 }


### PR DESCRIPTION
## Summary
Fixes typo in email subject line: `fufilled` → `fulfilled`.

## Fix
- `src/email-templates/schedulePickup.ts` line 25
- Changes: `subject: 'Your Baby Product Exchange order has been fufilled'` → `subject: 'Your Baby Product Exchange order has been fulfilled'`

## Testing
- Local syntax check passed
- Single surgical text fix, no logic changes

---
*Automated fix via surgical typo workflow.*